### PR TITLE
Removed unused date and better typed optional ID

### DIFF
--- a/imports/api/database.ts
+++ b/imports/api/database.ts
@@ -1,4 +1,5 @@
+import { Mongo } from "meteor/mongo";
+
 export interface DBEntry {
-  _id: string;
-  createdAt: Date;
+  _id?: Mongo.ObjectID;
 }


### PR DESCRIPTION
Changes:
- Updated `_id` field to be optional as this is an auto-generated field and should not be manually included on insert (TypeScript will complain if you omit it from insertions if it isn't optional though).
- Updated type of `_id` field to be more accurate.
- Removed `createdAt` field, this does not seem to be auto-generated (although in my experience it usually is with MongoDB). If we want this to be auto-generated for all our database entries then we should split that out into another ticket although probably unnecessary for MVP.