### PR TITLE
Creating menuItems collection

### DIFF
--- a/imports/api/MenuItemsCollection.ts
+++ b/imports/api/MenuItemsCollection.ts
@@ -2,8 +2,6 @@ import { Mongo } from "meteor/mongo";
 import { DBEntry } from "./database";
 
 export interface MenuItem extends DBEntry {
-  _id: string;
-  createdAt: Date;
   name: string;
   quantity: number;
   ingredients: string[];

--- a/imports/api/MenuItemsCollection.ts
+++ b/imports/api/MenuItemsCollection.ts
@@ -1,0 +1,12 @@
+import { Mongo } from "meteor/mongo";
+import { DBEntry } from "./database";
+
+export interface MenuItem extends DBEntry {
+  _id: string;
+  createdAt: Date;
+  name: string;
+  quantity: number;
+  ingredients: string[];
+}
+
+export const MenuItemsCollection = new Mongo.Collection<MenuItem>("menuItems");

--- a/imports/api/menuItemsMethods.ts
+++ b/imports/api/menuItemsMethods.ts
@@ -1,0 +1,8 @@
+import { Meteor } from "meteor/meteor";
+import { MenuItem, MenuItemsCollection } from "./MenuItemsCollection";
+
+Meteor.methods({
+  'menuItems.insert'(item: MenuItem) {
+    MenuItemsCollection.insert(item);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.1.tgz",
-      "integrity": "sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.2.tgz",
+      "integrity": "sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,7 @@ import { Meteor } from "meteor/meteor";
 import { StockItemsCollection } from "/imports/api/stock_item";
 import { MenuItemsCollection } from "../imports/api/MenuItemsCollection";
 
+// Method for inserting new items to menuItems collection
 const insertMenuItem = (itemName: string, quantity: number, ingredients: string[]) =>
   MenuItemsCollection.insertAsync({
     name: itemName,
@@ -16,17 +17,16 @@ Meteor.startup(async () => {
   });
 
 
-  // 
+  // Dropping menuItems collection when application first runs
   MenuItemsCollection.dropCollectionAsync()
 
-
-  // Hardcoded for now
+  // Hardcoded menu items for now
   const pressUpMenuItems: [string, number, string[]][] = [
     ["Soy Latte", Math.floor(Math.random()*10), ["Soy Milk", "Espresso"]],
     ["Beef Burger", Math.floor(Math.random()*10), ["Beef Patty", "Lettuce", "Cheese"]]
   ];
 
-  // Adding menu items to the menuItems databse
+  // Adding menu items to the menuItems collection
   for (let i = 0; i < pressUpMenuItems.length; i++) {
     let itemName = pressUpMenuItems[i][0];
     let quantity = pressUpMenuItems[i][1];

--- a/server/main.ts
+++ b/server/main.ts
@@ -8,7 +8,6 @@ const insertMenuItem = (itemName: string, quantity: number, ingredients: string[
     name: itemName,
     quantity: quantity,
     ingredients: ingredients,
-    createdAt: new Date(),
 });
 
 Meteor.startup(async () => {

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,8 +1,39 @@
 import { Meteor } from "meteor/meteor";
 import { StockItemsCollection } from "/imports/api/stock_item";
+import { MenuItemsCollection } from "../imports/api/MenuItemsCollection";
+
+const insertMenuItem = (itemName: string, quantity: number, ingredients: string[]) =>
+  MenuItemsCollection.insertAsync({
+    name: itemName,
+    quantity: quantity,
+    ingredients: ingredients,
+    createdAt: new Date(),
+});
 
 Meteor.startup(async () => {
   Meteor.publish("stock_items", function () {
     return StockItemsCollection.find();
   });
+
+
+  // 
+  MenuItemsCollection.dropCollectionAsync()
+
+
+  // Hardcoded for now
+  const pressUpMenuItems: [string, number, string[]][] = [
+    ["Soy Latte", Math.floor(Math.random()*10), ["Soy Milk", "Espresso"]],
+    ["Beef Burger", Math.floor(Math.random()*10), ["Beef Patty", "Lettuce", "Cheese"]]
+  ];
+
+  // Adding menu items to the menuItems databse
+  for (let i = 0; i < pressUpMenuItems.length; i++) {
+    let itemName = pressUpMenuItems[i][0];
+    let quantity = pressUpMenuItems[i][1];
+    let ingredients = pressUpMenuItems[i][2];
+    
+    insertMenuItem(itemName, quantity, ingredients);
+  }
+
+
 });


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86cym47bj

- Initialised the "menuItems" collection in the database "meteor" with minimal attributes
- This can be viewed in NoSQLBooster or any other MongoDB platform by connecting the the connection string "mongodb://127.0.0.1:3001/meteor" (confirm by running `meteor mongo -U` in terminal)
- Currently code clears entire collection and adds two documents when the application runs
- Yet to be integrated with any functional methods
 
Example of document added:
<img width="674" alt="image" src="https://github.com/user-attachments/assets/e56218ea-2b9f-4514-aeba-4832b9ef5fea" />
