### PR TITLE
Discount Functionality in POS Display

### DIFF
--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -8,6 +8,8 @@ interface PosSideMenuProps {
 }
 
 export const PosSideMenu = ({ items }: PosSideMenuProps) => {
+  let totalCost = 40.00; // Hardcoding total cost for now
+
   const [localQuantities, setLocalQuantities] = useState<{ [id: string]: number }>(
     Object.fromEntries(items.map((item) => [String(item._id), item.quantity]))
   );
@@ -31,18 +33,18 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
 
   const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
   const [discountPercent, setDiscountPercent] = useState(0)
-  const [finalTotal, setFinalTotal] = useState(40.00)
+  const [originalTotal, setOriginalTotal] = useState(totalCost);
+  const [finalTotal, setFinalTotal] = useState(totalCost)
   const [savedAmount, setSavedAmount] = useState(0)
 
   const applyDiscount = (percentage:number) => {
     const discountPercentage = percentage;
-    const discountedFinalTotal = finalTotal - (finalTotal * (discountPercentage/100));
-    const savedCost = finalTotal - discountedFinalTotal;
-    const totalSaved = savedAmount + savedCost;
+    const discountedFinalTotal = originalTotal - (originalTotal * (discountPercentage/100));
+    const savedCost = originalTotal - discountedFinalTotal;
     setDiscountPercent(discountPercentage);
     setFinalTotal(discountedFinalTotal);
+    setSavedAmount(savedCost);
     setOpenDiscountPopup(false);
-    setSavedAmount(totalSaved);
   };
 
 
@@ -91,7 +93,7 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
         {/* Displaying total cost*/}
         <div className="flex justify-between items-center mb-2">
           <span className="text-lg font-bold">Total</span>
-          <span className="text-lg font-bold">$40.00</span> {/* Static total for now */}
+          <span className="text-lg font-bold">${finalTotal.toFixed(2)}</span> {/* Static total for now */}
         </div>
         
         {/* Shows how much discount is applied*/}
@@ -124,8 +126,8 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
 
             <div className="w-180 h-100 bg-pink-200 rounded-2xl mx-10 p-8">
               <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
-              <div className="grid grid-cols-3 gap-1 my-4">
-                {[5, 10, 15, 20, 25, 30, 35, 40, 50].map((d) => (
+              <div className="grid grid-cols-4 gap-1 my-4">
+                {[5, 10, 25, 50].map((d) => (
                   <button key={d} className="bg-pink-700 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyDiscount(d)}>
                     {d}%
                   </button>

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -132,7 +132,6 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
                 ))}
               </div>
             </div>
-            <div className="w-180 h-100 bg-pink-200 rounded-2xl mx-10"></div>
           </div>
           )
         }

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -29,9 +29,25 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
     });
   };
 
+  const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
+  const [discountPercent, setDiscountPercent] = useState(0)
+  const [finalTotal, setFinalTotal] = useState(40.00)
+  const [savedAmount, setSavedAmount] = useState(0)
+
+  const applyDiscount = (percentage:number) => {
+    const discountPercentage = percentage;
+    const discountedFinalTotal = finalTotal - (finalTotal * (discountPercentage/100));
+    const savedCost = finalTotal - discountedFinalTotal;
+    const totalSaved = savedAmount + savedCost;
+    setDiscountPercent(discountPercentage);
+    setFinalTotal(discountedFinalTotal);
+    setOpenDiscountPopup(false);
+    setSavedAmount(totalSaved);
+  };
+
 
   return (
-    <div className="w-64 bg-gray-100 flex flex-col pb-20 h-screen">
+    <div className="w-64 bg-gray-100 flex flex-col h-screen">
       {/* Sidebar Header */}
       <div className="flex items-center justify-between bg-rose-400 text-white px-4 py-2 rounded-t-md">
         <button className="text-2xl font-bold">⋯</button>
@@ -70,12 +86,66 @@ export const PosSideMenu = ({ items }: PosSideMenuProps) => {
         ))}
       </div>
 
-      {/* Total and Pay Button */}
+      {/* Total Cost + Discount Button + Pay Button */}
       <div className="bg-rose-400 text-white p-4 flex-shrink-0 sticky bottom-0">
-        <div className="flex justify-between items-center mb-4">
+        {/* Displaying total cost*/}
+        <div className="flex justify-between items-center mb-2">
           <span className="text-lg font-bold">Total</span>
           <span className="text-lg font-bold">$40.00</span> {/* Static total for now */}
         </div>
+        
+        {/* Shows how much discount is applied*/}
+        {discountPercent !== 0 && (
+          <div>
+            <div className="flex justify-between items-center mb-2 bg-yellow-400 text-black text-sm rounded-lg p-1">
+              <span className="text-sm font-bold">Last Discount Applied</span>
+              <span className="text-sm font-bold">{discountPercent}%</span>
+            </div>
+            <div className="flex justify-between items-center mb-2 bg-yellow-200 text-black text-sm rounded-lg p-1">
+              <span className="text-sm font-bold">Cost Saved</span>
+              <span className="text-sm font-bold">- ${savedAmount.toFixed(2)}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Discount button + popup*/}
+        <button className="w-full bg-orange-400 hover:bg-orange-300 text-white font-bold py-2 px-4 mb-2 rounded-full" onClick={() => setOpenDiscountPopup(true)}>
+          Discount
+        </button>
+
+        {
+          openDiscountPopup && (
+          <div className="fixed w-200 h-130 top-40 left-120 bg-pink-300 rounded-2xl">
+
+            <div className="flex flex-row justify-between mx-5 my-5">
+              <h1 className="font-bold text-2xl text-black">Apply Discount</h1>
+              <button className="bg-red-700 rounded-2xl w-8" onClick={()=> setOpenDiscountPopup(false)}>X</button>
+            </div>
+
+            <div className="w-180 h-100 bg-pink-200 rounded-2xl mx-10 p-8">
+              <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
+              <div className="grid grid-cols-3 gap-1 my-4">
+                {[5, 10, 15, 20, 25, 30, 35, 40, 50].map((d) => (
+                  <button key={d} className="bg-pink-700 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyDiscount(d)}>
+                    {d}%
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="w-180 h-100 bg-pink-200 rounded-2xl mx-10"></div>
+          </div>
+          )
+        }
+        {/* Reset Button */}
+        <button className="w-full bg-orange-700 hover:bg-orange-600 text-white font-bold py-2 px-4 mb-2 rounded-full"
+          onClick={() => {
+            setDiscountPercent(0);
+            setFinalTotal(40.00); 
+            setSavedAmount(0); 
+          }}>
+          Reset
+        </button>
+        
         {/* Link Pay button to Receipt page with Payment Modal*/}
         <PaymentModal></PaymentModal>
       </div>


### PR DESCRIPTION
Contributor:
@riyav1602 - Created Discount button, apply discount logic and create discount option page.
@JayReeMarine - Created Reset button.
@fung-alvin - Refined discount logic and integrated with pay button

This update adds a discount feature to the existing POS Side Panel.

How it works:

Initial State:
Before clicking the “Discount” button, no discount rate or cost savings are shown on the screen.
![image](https://github.com/user-attachments/assets/2f381f94-bcf0-49c2-ba10-4cea010b75cb)

Opening Discount Options:
After clicking the “Discount” button, a discount options panel appears.
Users can select a discount rate or close the panel by clicking the “X” button.
<img width="785" alt="image" src="https://github.com/user-attachments/assets/f768d125-4595-4b51-afc3-72604d9ece41" />

Applying Discount:
Once a discount rate is selected, the applied discount, amount saved, and discounted price are displayed. When a discount is already applied, and a new discount is selected, the price is override based on the latest discount selected.
![image](https://github.com/user-attachments/assets/7f6a20be-5325-4e40-9bda-b3a5079aaa05)

Resetting Discount:
Clicking the “Reset” button reverts the price back to its original value.