### PR TITLE
Update to Discount Functionality in POS Display

### DIFF
--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -13,9 +13,9 @@ interface PosSideMenuProps {
 
 export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: PosSideMenuProps) => {
   const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
-  const [discountPercent, setDiscountPercent] = useState(0) // For the discount % button
+  const [discountPercent, setDiscountPercent] = useState(0) // For the discount % button - final value used
   const [discountPercent2, setDiscountPercent2] = useState('') // For the discount % input field
-  const [discountAmount, setDiscountAmount] = useState(0) // For the discount $ button
+  const [discountAmount, setDiscountAmount] = useState(0) // For the discount $ button - final value used
   const [discountAmount2, setDiscountAmount2] = useState('') // For the discount $ input field
   const [savedAmount, setSavedAmount] = useState(0)
   const [discountPopupScreen, setDiscountPopupScreen] = useState<'menu' | 'percentage' | 'flat'>('menu');
@@ -41,23 +41,21 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
     setOpenDiscountPopup(false);
   };
 
+  // Allow 1-100% for discount percentage
   const handleDiscountPercent2Change = (percentage: React.ChangeEvent<HTMLInputElement>) => {
     const discountVal = parseInt(percentage.target.value, 10);
     if (!isNaN(discountVal) && discountVal >= 1 && discountVal <= 100) {
       setDiscountPercent2(discountVal);
     } else {
-      // Optional: Clear or set to a fallback value if invalid
       setDiscountPercent2('');
     }
   }
 
+  // Allow $0.01-max for discount amount
   const handleDiscountAmount2Change = (amount: React.ChangeEvent<HTMLInputElement>) => {
     const discountVal = amount.target.value;
     const num = parseFloat(discountVal);
-
-    // Allow numbers greater than 0, up to 2 decimal places
     const isValid = !isNaN(num) && num > 0 && /^\d+(\.\d{1,2})?$/.test(discountVal);
-
     if (isValid) {
       setDiscountAmount2(discountVal);
     }else {
@@ -104,15 +102,16 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
         ))}
       </div>
 
-      {/* Total Cost + Discount Button + Pay Button */}
+      {/* Total Cost */}
       <div className="bg-rose-400 text-white p-4 flex-shrink-0 sticky bottom-0">
         {/* Displaying total cost*/}
         <div className="flex justify-between items-center mb-2">
           <span className="text-lg font-bold">Total</span>
-          <span className="text-lg font-bold">${finalTotal.toFixed(2)}</span> {/* Static total for now */}
+          <span className="text-lg font-bold">${finalTotal.toFixed(2)}</span>
         </div>
       
 
+        {/* Displaying discount infomation*/}
         {discountPercent !== 0 && (
           <div className="flex justify-between items-center mb-2 bg-blue-200 text-black text-sm rounded-lg p-1">
             <span className="text-sm font-bold">Percent Discount: {discountPercent}%</span>
@@ -131,16 +130,17 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
           </div>
         )}
 
-        {/* Discount button + popup*/}
+        {/* Discount button */}
         <button className="w-full bg-orange-400 hover:bg-orange-300 text-white font-bold py-2 px-4 mb-2 rounded-full" onClick={() => {setOpenDiscountPopup(true); setDiscountPopupScreen('menu');}}>
           Discount
         </button>
 
+        {/* Discount Popup */}
         {
           openDiscountPopup && (
           <div>
             {/* Overlay for Popup */}
-            {/* <div className="fixed inset-0 bg-gray-700 bg-opacity-25 z-40" onClick={() => setOpenDiscountPopup(false)} /> */}
+            <div className="fixed inset-0 bg-gray-700/40 z-40" onClick={() => setOpenDiscountPopup(false)} />
             
             <div className="fixed w-200 h-135 top-40 left-120 bg-pink-300 rounded-2xl z-50">
               <div className="flex flex-row justify-between mx-5 my-5">
@@ -148,7 +148,7 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
                 <button className="bg-red-700 rounded-2xl w-8" onClick={()=> {setOpenDiscountPopup(false); setDiscountPopupScreen('menu');}}>X</button>
               </div>
 
-              {/* Discount Menu Popup*/}
+              {/* Discount Popup - Menu */}
               {discountPopupScreen === 'menu' && (
                 <div className="w-180 h-108 bg-pink-200 rounded-2xl mx-10 px-8 py-2">
                   <div className="px-2 py-4">
@@ -183,14 +183,14 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
                           setSavedAmount(0);
                           setOpenDiscountPopup(false);
                         }}>
-                        Reset
+                        Reset Discount
                       </button>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/*Percentage Discount Popup*/}
+              {/*Discount Popup - Percentage Discount */}
               {discountPopupScreen === 'percentage' && (
                 <div className="w-180 h-108 bg-blue-100 rounded-2xl mx-10 px-8 py-8">
                   <div className="flex flex-row justify-between">
@@ -217,7 +217,7 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
                 </div>
               )}
 
-              {/*Flat Discount Popup*/}
+              {/*Discount Popup - Flat Discount */}
               {discountPopupScreen === 'flat' && (
                 <div className="w-180 h-108 bg-purple-200 rounded-2xl mx-10 px-8 py-8">
                   <div className="flex flex-row justify-between">
@@ -246,8 +246,6 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
             </div>
           </div>
         )}
-
-
         
         {/* Link Pay button to Receipt page with Payment Modal*/}
         <PaymentModal></PaymentModal>

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -174,17 +174,24 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
                       <button className="bg-purple-500 hover:bg-purple-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('flat')}>
                         Flat Discount ($)
                       </button>
-                      <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 w-full my-4 rounded-full"
-                        onClick={() => {
-                          setDiscountPercent(0);
-                          setDiscountPercent2('');
-                          setDiscountAmount(0);
-                          setDiscountAmount2('');
-                          setSavedAmount(0);
-                          setOpenDiscountPopup(false);
-                        }}>
-                        Reset Discount
-                      </button>
+                      <div className="flex flex-row w-full justify-between">
+                        <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 my-4 px-6 rounded-full"
+                          onClick={() => {
+                            setDiscountPercent(0);
+                            setDiscountPercent2('');
+                            setOpenDiscountPopup(false);
+                          }}>
+                          Reset Percentage Discount (%)
+                        </button>
+                        <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 my-4 px-8 rounded-full"
+                          onClick={() => {
+                            setDiscountAmount(0);
+                            setDiscountAmount2('');
+                            setOpenDiscountPopup(false);
+                          }}>
+                          Reset Flat Discount ($)
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -19,15 +19,17 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
   const [discountAmount2, setDiscountAmount2] = useState('') // For the discount $ input field
   const [savedAmount, setSavedAmount] = useState(0)
   const [discountPopupScreen, setDiscountPopupScreen] = useState<'menu' | 'percentage' | 'flat'>('menu');
+  const [finalTotal, setFinalTotal] = useState(total);
 
-
-  // Recalculate saved amount when total or discount changes
-  const finalTotal = total - (total * (discountPercent / 100));
 
   useEffect(() => {
-    const saved = total - finalTotal;
+    const paymentTotal = total - (total * (discountPercent / 100)) - discountAmount;
+    const final = paymentTotal < 0 ? 0 : paymentTotal;
+    setFinalTotal(final);
+    const saved = total - final;
     setSavedAmount(saved);
-  }, [total, discountPercent]);
+  }, [total, discountPercent, discountAmount]);
+
 
   const applyPercentDiscount = (percentage: number) => {
     setDiscountPercent(percentage);
@@ -109,18 +111,23 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
           <span className="text-lg font-bold">Total</span>
           <span className="text-lg font-bold">${finalTotal.toFixed(2)}</span> {/* Static total for now */}
         </div>
-        
-        {/* Shows how much discount is applied*/}
+      
+
         {discountPercent !== 0 && (
-          <div>
-            <div className="flex justify-between items-center mb-2 bg-yellow-400 text-black text-sm rounded-lg p-1">
-              <span className="text-sm font-bold">Last Discount Applied</span>
-              <span className="text-sm font-bold">{discountPercent}%</span>
-            </div>
-            <div className="flex justify-between items-center mb-2 bg-yellow-200 text-black text-sm rounded-lg p-1">
-              <span className="text-sm font-bold">Cost Saved</span>
-              <span className="text-sm font-bold">- ${savedAmount.toFixed(2)}</span>
-            </div>
+          <div className="flex justify-between items-center mb-2 bg-blue-200 text-black text-sm rounded-lg p-1">
+            <span className="text-sm font-bold">Percent Discount: {discountPercent}%</span>
+          </div>
+        )}
+
+        {discountAmount !== 0 && (
+          <div className="flex justify-between items-center mb-2 bg-purple-200 text-black text-sm rounded-lg p-1">
+            <span className="text-sm font-bold">Flat Discount: ${discountAmount}</span>
+          </div>
+        )}
+
+        {savedAmount !== 0 && (
+          <div className="flex justify-between items-center mb-2 bg-yellow-200 text-black text-sm rounded-lg p-1">
+            <span className="text-sm font-bold">Cost Saved: - ${savedAmount.toFixed(2)}</span>
           </div>
         )}
 
@@ -131,94 +138,112 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
 
         {
           openDiscountPopup && (
-          <div className="fixed w-200 h-135 top-40 left-120 bg-pink-300 rounded-2xl">
-            <div className="flex flex-row justify-between mx-5 my-5">
-              <h1 className="font-bold text-2xl text-black">Apply Discount</h1>
-              <button className="bg-red-700 rounded-2xl w-8" onClick={()=> {setOpenDiscountPopup(false); setDiscountPopupScreen('menu');}}>X</button>
+          <div>
+            {/* Overlay for Popup */}
+            {/* <div className="fixed inset-0 bg-gray-700 bg-opacity-25 z-40" onClick={() => setOpenDiscountPopup(false)} /> */}
+            
+            <div className="fixed w-200 h-135 top-40 left-120 bg-pink-300 rounded-2xl z-50">
+              <div className="flex flex-row justify-between mx-5 my-5">
+                <h1 className="font-bold text-2xl text-black">Apply Discount</h1>
+                <button className="bg-red-700 rounded-2xl w-8" onClick={()=> {setOpenDiscountPopup(false); setDiscountPopupScreen('menu');}}>X</button>
+              </div>
+
+              {/* Discount Menu Popup*/}
+              {discountPopupScreen === 'menu' && (
+                <div className="w-180 h-108 bg-pink-200 rounded-2xl mx-10 px-8 py-2">
+                  <div className="px-2 py-4">
+                    <div className="flex flex-row justify-between">
+                      <span className="font-bold text-2xl text-black rounded-full py-2">Discount Options</span>
+                      {discountPercent !== 0 && (
+                        <div className="flex justify-between items-center mb-2 bg-blue-300 text-black text-sm rounded-lg p-2 px-4">
+                          <span className="text-sm font-bold">Percentage Discount (%): </span>
+                          <span className="text-sm font-bold">{discountPercent}%</span>
+                        </div>
+                      )}
+                     {discountAmount !== 0 && (
+                        <div className="flex justify-between items-center mb-2 bg-purple-300 text-black text-sm rounded-lg p-2">
+                          <span className="text-sm font-bold">Flat Discount ($): </span>
+                          <span className="text-sm font-bold">${discountAmount}</span>
+                        </div>
+                      )}                      
+                    </div>
+                    <div className="flex flex-col items-center mt-7">
+                      <button className="bg-blue-500 hover:bg-blue-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('percentage')}>
+                        Percentage Discount (%)
+                      </button>
+                      <button className="bg-purple-500 hover:bg-purple-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('flat')}>
+                        Flat Discount ($)
+                      </button>
+                      <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 w-full my-4 rounded-full"
+                        onClick={() => {
+                          setDiscountPercent(0);
+                          setDiscountPercent2('');
+                          setDiscountAmount(0);
+                          setDiscountAmount2('');
+                          setSavedAmount(0);
+                          setOpenDiscountPopup(false);
+                        }}>
+                        Reset
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/*Percentage Discount Popup*/}
+              {discountPopupScreen === 'percentage' && (
+                <div className="w-180 h-108 bg-blue-100 rounded-2xl mx-10 px-8 py-8">
+                  <div className="flex flex-row justify-between">
+                    <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Percentage Discount (%)</span>
+                    <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
+                  </div>
+                  <div className="mt-4">
+                    <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
+                    <div className="grid grid-cols-4 gap-1 my-2">
+                      {[5, 10, 25, 50].map((d) => (
+                        <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyPercentDiscount(d)}>
+                          {d}%
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex flex-col my-8">
+                      <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Percentage (%)</span>
+                      <input type="number" min={1} max={100} step={1} value={discountPercent2} onChange={handleDiscountPercent2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
+                      <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyPercentDiscount(discountPercent2)}>
+                        Apply
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/*Flat Discount Popup*/}
+              {discountPopupScreen === 'flat' && (
+                <div className="w-180 h-108 bg-purple-200 rounded-2xl mx-10 px-8 py-8">
+                  <div className="flex flex-row justify-between">
+                    <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Flat Discount ($)</span>
+                    <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
+                  </div>
+                  <div className="mt-4">
+                    <span className="font-bold text-xl text-gray-700">Select Discount Amount</span>
+                    <div className="grid grid-cols-4 gap-1 my-2">
+                      {[5, 10, 15, 20].map((d) => (
+                        <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyFlatDiscount(d)}>
+                          ${d}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex flex-col my-8">
+                      <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Amount ($)</span>
+                      <input type="number" min={0.01} step={0.01} value={discountAmount2} onChange={handleDiscountAmount2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
+                      <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyFlatDiscount(discountAmount2)}>
+                        Apply
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
-
-            {/* Discount Menu Popup*/}
-            {discountPopupScreen === 'menu' && (
-              <div className="w-180 h-108 bg-pink-200 rounded-2xl mx-10 px-8 py-2">
-                <div className="px-2 py-4">
-                  <span className="font-bold text-2xl text-black rounded-full py-2">Discount Options</span>
-      
-                  <div className="flex flex-col items-center">
-                    <button className="bg-blue-500 hover:bg-blue-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('percentage')}>
-                      Percentage Discount (%)
-                    </button>
-                    <button className="bg-purple-500 hover:bg-purple-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('flat')}>
-                      Flat Discount ($)
-                    </button>
-                    <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 w-full my-4 rounded-full"
-                      onClick={() => {
-                        setDiscountPercent(0);
-                        setDiscountPercent2('');
-                        setDiscountAmount(0);
-                        setDiscountAmount2('');
-                        setSavedAmount(0);
-                        setOpenDiscountPopup(false);
-                      }}>
-                      Reset
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/*Percentage Discount Popup*/}
-            {discountPopupScreen === 'percentage' && (
-              <div className="w-180 h-108 bg-blue-100 rounded-2xl mx-10 px-8 py-8">
-                <div className="flex flex-row justify-between">
-                  <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Percentage Discount (%)</span>
-                  <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
-                </div>
-                <div className="mt-4">
-                  <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
-                  <div className="grid grid-cols-4 gap-1 my-2">
-                    {[5, 10, 25, 50].map((d) => (
-                      <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyPercentDiscount(d)}>
-                        {d}%
-                      </button>
-                    ))}
-                  </div>
-                  <div className="flex flex-col my-8">
-                    <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Percentage (%)</span>
-                    <input type="number" min={1} max={100} step={1} value={discountPercent2} onChange={handleDiscountPercent2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
-                    <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyPercentDiscount(discountPercent2)}>
-                      Apply
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/*Flat Discount Popup*/}
-            {discountPopupScreen === 'flat' && (
-              <div className="w-180 h-108 bg-purple-200 rounded-2xl mx-10 px-8 py-8">
-                <div className="flex flex-row justify-between">
-                  <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Flat Discount ($)</span>
-                  <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
-                </div>
-                <div className="mt-4">
-                  <span className="font-bold text-xl text-gray-700">Select Discount Amount</span>
-                  <div className="grid grid-cols-4 gap-1 my-2">
-                    {[5, 10, 15, 20].map((d) => (
-                      <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyFlatDiscount(d)}>
-                        ${d}
-                      </button>
-                    ))}
-                  </div>
-                  <div className="flex flex-col my-8">
-                    <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Amount ($)</span>
-                    <input type="number" min={0.01} step={0.01} value={discountAmount2} onChange={handleDiscountAmount2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
-                    <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyFlatDiscount(discountAmount2)}>
-                      Apply
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
         )}
 

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -13,8 +13,13 @@ interface PosSideMenuProps {
 
 export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: PosSideMenuProps) => {
   const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
-  const [discountPercent, setDiscountPercent] = useState(0)
+  const [discountPercent, setDiscountPercent] = useState(0) // For the discount % button
+  const [discountPercent2, setDiscountPercent2] = useState('') // For the discount % input field
+  const [discountAmount, setDiscountAmount] = useState(0) // For the discount $ button
+  const [discountAmount2, setDiscountAmount2] = useState('') // For the discount $ input field
   const [savedAmount, setSavedAmount] = useState(0)
+  const [discountPopupScreen, setDiscountPopupScreen] = useState<'menu' | 'percentage' | 'flat'>('menu');
+
 
   // Recalculate saved amount when total or discount changes
   const finalTotal = total - (total * (discountPercent / 100));
@@ -24,10 +29,39 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
     setSavedAmount(saved);
   }, [total, discountPercent]);
 
-  const applyDiscount = (percentage: number) => {
+  const applyPercentDiscount = (percentage: number) => {
     setDiscountPercent(percentage);
     setOpenDiscountPopup(false);
   };
+
+  const applyFlatDiscount = (amount: number) => {
+    setDiscountAmount(amount);
+    setOpenDiscountPopup(false);
+  };
+
+  const handleDiscountPercent2Change = (percentage: React.ChangeEvent<HTMLInputElement>) => {
+    const discountVal = parseInt(percentage.target.value, 10);
+    if (!isNaN(discountVal) && discountVal >= 1 && discountVal <= 100) {
+      setDiscountPercent2(discountVal);
+    } else {
+      // Optional: Clear or set to a fallback value if invalid
+      setDiscountPercent2('');
+    }
+  }
+
+  const handleDiscountAmount2Change = (amount: React.ChangeEvent<HTMLInputElement>) => {
+    const discountVal = amount.target.value;
+    const num = parseFloat(discountVal);
+
+    // Allow numbers greater than 0, up to 2 decimal places
+    const isValid = !isNaN(num) && num > 0 && /^\d+(\.\d{1,2})?$/.test(discountVal);
+
+    if (isValid) {
+      setDiscountAmount2(discountVal);
+    }else {
+      setDiscountAmount2('');
+    }
+  }
 
   return (
     <div className="w-64 bg-gray-100 flex flex-col h-screen">
@@ -91,38 +125,104 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease }: P
         )}
 
         {/* Discount button + popup*/}
-        <button className="w-full bg-orange-400 hover:bg-orange-300 text-white font-bold py-2 px-4 mb-2 rounded-full" onClick={() => setOpenDiscountPopup(true)}>
+        <button className="w-full bg-orange-400 hover:bg-orange-300 text-white font-bold py-2 px-4 mb-2 rounded-full" onClick={() => {setOpenDiscountPopup(true); setDiscountPopupScreen('menu');}}>
           Discount
         </button>
 
         {
           openDiscountPopup && (
-          <div className="fixed w-200 h-130 top-40 left-120 bg-pink-300 rounded-2xl">
+          <div className="fixed w-200 h-135 top-40 left-120 bg-pink-300 rounded-2xl">
             <div className="flex flex-row justify-between mx-5 my-5">
               <h1 className="font-bold text-2xl text-black">Apply Discount</h1>
-              <button className="bg-red-700 rounded-2xl w-8" onClick={()=> setOpenDiscountPopup(false)}>X</button>
+              <button className="bg-red-700 rounded-2xl w-8" onClick={()=> {setOpenDiscountPopup(false); setDiscountPopupScreen('menu');}}>X</button>
             </div>
-            <div className="w-180 h-100 bg-pink-200 rounded-2xl mx-10 p-8">
-              <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
-              <div className="grid grid-cols-4 gap-1 my-4">
-                {[5, 10, 25, 50].map((d) => (
-                  <button key={d} className="bg-pink-700 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyDiscount(d)}>
-                    {d}%
-                  </button>
-                ))}
+
+            {/* Discount Menu Popup*/}
+            {discountPopupScreen === 'menu' && (
+              <div className="w-180 h-108 bg-pink-200 rounded-2xl mx-10 px-8 py-2">
+                <div className="px-2 py-4">
+                  <span className="font-bold text-2xl text-black rounded-full py-2">Discount Options</span>
+      
+                  <div className="flex flex-col items-center">
+                    <button className="bg-blue-500 hover:bg-blue-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('percentage')}>
+                      Percentage Discount (%)
+                    </button>
+                    <button className="bg-purple-500 hover:bg-purple-400 font-bold text-white text-xl py-4 rounded text-center w-full my-4 rounded-full" onClick={() => setDiscountPopupScreen('flat')}>
+                      Flat Discount ($)
+                    </button>
+                    <button className="bg-orange-700 hover:bg-orange-600 text-white font-bold text-xl py-4 w-full my-4 rounded-full"
+                      onClick={() => {
+                        setDiscountPercent(0);
+                        setDiscountPercent2('');
+                        setDiscountAmount(0);
+                        setDiscountAmount2('');
+                        setSavedAmount(0);
+                        setOpenDiscountPopup(false);
+                      }}>
+                      Reset
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
+            )}
+
+            {/*Percentage Discount Popup*/}
+            {discountPopupScreen === 'percentage' && (
+              <div className="w-180 h-108 bg-blue-100 rounded-2xl mx-10 px-8 py-8">
+                <div className="flex flex-row justify-between">
+                  <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Percentage Discount (%)</span>
+                  <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
+                </div>
+                <div className="mt-4">
+                  <span className="font-bold text-xl text-gray-700">Select Discount Percentage</span>
+                  <div className="grid grid-cols-4 gap-1 my-2">
+                    {[5, 10, 25, 50].map((d) => (
+                      <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyPercentDiscount(d)}>
+                        {d}%
+                      </button>
+                    ))}
+                  </div>
+                  <div className="flex flex-col my-8">
+                    <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Percentage (%)</span>
+                    <input type="number" min={1} max={100} step={1} value={discountPercent2} onChange={handleDiscountPercent2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
+                    <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyPercentDiscount(discountPercent2)}>
+                      Apply
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/*Flat Discount Popup*/}
+            {discountPopupScreen === 'flat' && (
+              <div className="w-180 h-108 bg-purple-200 rounded-2xl mx-10 px-8 py-8">
+                <div className="flex flex-row justify-between">
+                  <span className="font-bold text-2xl text-black rounded-full whitespace-nowrap">Apply Flat Discount ($)</span>
+                  <button className="text-xl text-white font-bold rounded-full bg-orange-500 hover:bg-orange-400 px-3 py-2" onClick={() => setDiscountPopupScreen('menu')}>← Back</button>
+                </div>
+                <div className="mt-4">
+                  <span className="font-bold text-xl text-gray-700">Select Discount Amount</span>
+                  <div className="grid grid-cols-4 gap-1 my-2">
+                    {[5, 10, 15, 20].map((d) => (
+                      <button key={d} className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl h-18 rounded text-center mx-4 my-2 rounded-full" onClick={() => applyFlatDiscount(d)}>
+                        ${d}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="flex flex-col my-8">
+                    <span className="mb-2 font-bold text-xl text-gray-700">Enter Discount Amount ($)</span>
+                    <input type="number" min={0.01} step={0.01} value={discountAmount2} onChange={handleDiscountAmount2Change} className="px-4 py-3 w-full text-xl h-12 w-64 bg-pink-100 border border-gray-300 text-black rounded focus:outline-none focus:ring-2 focus:ring-pink-300"></input>
+                    <button className="bg-pink-700 hover:bg-pink-600 font-bold text-white text-xl py-2 rounded text-center mr-130 my-4 rounded-full" onClick={() => applyFlatDiscount(discountAmount2)}>
+                      Apply
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         )}
 
-        <button
-          className="w-full bg-orange-700 hover:bg-orange-600 text-white font-bold py-2 px-4 mb-2 rounded-full"
-          onClick={() => {
-            setDiscountPercent(0);
-            setSavedAmount(0);
-          }}>
-          Reset
-        </button>
+
         
         {/* Link Pay button to Receipt page with Payment Modal*/}
         <PaymentModal></PaymentModal>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "dependencies": {
         "@babel/core": "^7.26.10",
         "@babel/plugin-transform-react-jsx": "^7.25.9",
-        "@babel/runtime": "^7.20.7",
-        "@faker-js/faker": "^9.7.0",
+        "@babel/runtime": "^7.27.1",
+        "@faker-js/faker": "^9.8.0",
         "@tailwindcss/postcss": "^4.1.4",
         "imports": "^1.0.0",
         "lucide-react": "^0.510.0",
         "meteor-node-stubs": "^1.2.5",
         "postcss": "^8.5.3",
         "postcss-load-config": "^6.0.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router": "^7.5.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router": "^7.6.0",
         "tailwindcss": "^4.1.4"
       },
       "devDependencies": {
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
-      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
+      "integrity": "sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3195,14 +3195,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
-      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3368,12 +3367,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   "dependencies": {
     "@babel/core": "^7.26.10",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
-    "@babel/runtime": "^7.20.7",
-    "@faker-js/faker": "^9.7.0",
+    "@babel/runtime": "^7.27.1",
+    "@faker-js/faker": "^9.8.0",
     "@tailwindcss/postcss": "^4.1.4",
     "imports": "^1.0.0",
     "lucide-react": "^0.510.0",
     "meteor-node-stubs": "^1.2.5",
     "postcss": "^8.5.3",
     "postcss-load-config": "^6.0.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router": "^7.5.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router": "^7.6.0",
     "tailwindcss": "^4.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
**Contributor:**
@riyav1602 - Added a flat discount option, added input fields to allow both flat and percent discount to have misc values (with validation in place), changed discount popup (now it has 3 separate screens with navigation - the menu, percent discount and flat discount), changed placement of reset button and split reseting the discount into 2 buttons (one for each type of discount).

**How it works:**
1) Reset button was removed from side panel and moved into the discount popup - now there are 2 reset buttons (one for each type of discount reset).
![image](https://github.com/user-attachments/assets/21974173-bccc-4a31-8afc-a83f87d608b1)

![image](https://github.com/user-attachments/assets/a0c37985-5bdb-4c02-b544-0263789da95c)

2) Percentage discount and flat discount screens (using blue theme for percent and purple for flat to help user differentiate between the two easily).
![image](https://github.com/user-attachments/assets/3d043f6b-bc81-4b8d-ad93-5b461a508b9b)

![image](https://github.com/user-attachments/assets/4675ce9c-8f90-44c5-9567-1c050ffeb121)

3) When any type of discount is applied you can see it both in the discount popup as well as the side panel.
![image](https://github.com/user-attachments/assets/844e9554-75a8-46a0-bdc6-398053ac8bb0)

![image](https://github.com/user-attachments/assets/8ded5972-530c-4f2c-a62d-59d06336a95f)

**Other things to note:**
- Flat discount and percent discount can be stacked (but each one gets overriden if changed).
