### PR TITLE
Removed confirmation when deleting an ingredient or category

### DIFF
--- a/imports/ui/components/CategoryDropdown.tsx
+++ b/imports/ui/components/CategoryDropdown.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect, useRef } from 'react';
-import { ConfirmModal } from './ConfirmModal';
 
 interface CategoryProps {
     selectedCategories: string[];
@@ -16,8 +15,6 @@ export const CategoryDropdown: React.FC<CategoryProps> = ({
     const containerRef = useRef<HTMLDivElement>(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [ searchCategory, setSearchCategory ] = useState("");
-    const [ showConfirmation, setShowConfirmation ] = useState(false);
-    const [ categoryDelete, setCategoryDelete ] = useState<string | null>(null)
 
     const updatecategories = (category: string) => {
         if (selectedCategories.includes(category)) {
@@ -58,7 +55,6 @@ export const CategoryDropdown: React.FC<CategoryProps> = ({
     }, []);
 
     return (
-        <>
         <div className="relative" ref={containerRef}>
             <input
                 type="text"
@@ -88,8 +84,7 @@ export const CategoryDropdown: React.FC<CategoryProps> = ({
                             className="text-red-500 hover:bg-red-100 rounded-full w-5 h-5 flex items-center justify-center ml-4"
                             title="Delete category"
                             onClick={() => {
-                                setShowConfirmation(true);
-                                setCategoryDelete(category);
+                                deleteCategory(category);
                             }}
                         >
                             x
@@ -121,18 +116,5 @@ export const CategoryDropdown: React.FC<CategoryProps> = ({
                 </ul>
             )}
         </div>
-        <ConfirmModal
-                open={showConfirmation}
-                message="Are you sure you want to delete this category?"
-
-                onConfirm={() => {
-                    deleteCategory(categoryDelete);
-                    setShowConfirmation(false);
-                    }}
-                onCancel={() =>{
-                    setShowConfirmation(false);
-                }}
-            />
-        </>
     );
 }

--- a/imports/ui/components/IngredientDropdown.tsx
+++ b/imports/ui/components/IngredientDropdown.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect, useRef } from 'react';
-import { ConfirmModal } from './ConfirmModal';
 
 interface IngredientProps {
     selectedIngredients: string[];
@@ -16,8 +15,6 @@ export const IngredientDropdown: React.FC<IngredientProps> = ({
     const containerRef = useRef<HTMLDivElement>(null);
     const [showDropdown, setShowDropdown] = useState(false);
     const [ searchIngredient, setSearchIngredient ] = useState("");
-    const [ showConfirmation, setShowConfirmation ] = useState(false);
-    const [ ingredientDelete, setIngredientDelete ] = useState<string | null>(null)
 
     const updateIngredients = (ingredient: string) => {
         if (selectedIngredients.includes(ingredient)) {
@@ -58,7 +55,6 @@ export const IngredientDropdown: React.FC<IngredientProps> = ({
     }, []);
 
     return (
-        <>
         <div className="relative" ref={containerRef}>
             <input
                 type="text"
@@ -88,8 +84,7 @@ export const IngredientDropdown: React.FC<IngredientProps> = ({
                             className="text-red-500 hover:bg-red-100 rounded-full w-5 h-5 flex items-center justify-center ml-4"
                             title="Delete ingredient"
                             onClick={() => {
-                                setShowConfirmation(true);
-                                setIngredientDelete(ingredient);
+                                deleteIngredient(ingredient);
                             }}
                         >
                             x
@@ -121,19 +116,5 @@ export const IngredientDropdown: React.FC<IngredientProps> = ({
                 </ul>
             )}
         </div>
-
-        <ConfirmModal
-                open={showConfirmation}
-                message="Are you sure you want to delete this ingredient?"
-
-                onConfirm={() => {
-                    deleteIngredient(ingredientDelete);
-                    setShowConfirmation(false);
-                    }}
-                onCancel={() =>{
-                    setShowConfirmation(false);
-                }}
-            />
-        </>
     );
 }


### PR DESCRIPTION
No more confirmation prompts when deleting and ingredient or category within the edit menu item modal
![image](https://github.com/user-attachments/assets/060dcb64-fd87-42e9-970b-98f212e056e0)
