### PR TITLE
UI/supplier detailed information

### DIFF
--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -153,11 +153,11 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-gray-50">
-                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200 rounded-l">No.</th>
-                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Date</th>
-                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Goods</th>
-                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Quantity</th>
-                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200 rounded-r">
+                  <th className="text-left p-2 font-medium text-white rounded-l" style={{backgroundColor: '#6f597b'}}>No.</th>
+                  <th className="text-left p-2 font-medium text-white" style={{backgroundColor: '#6f597b'}}>Date</th>
+                  <th className="text-left p-2 font-medium text-white" style={{backgroundColor: '#6f597b'}}>Goods</th>
+                  <th className="text-left p-2 font-medium text-white" style={{backgroundColor: '#6f597b'}}>Quantity</th>
+                  <th className="text-left p-2 font-medium text-white rounded-r" style={{backgroundColor: '#6f597b'}}>
                     Total Cost <span className="text-xs">(Inc GST)</span>
                   </th>
                   <th className="text-left p-2 font-medium text-gray-600"></th>
@@ -172,9 +172,13 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
                     <td className="p-2 text-gray-800">{order.quantity}</td>
                     <td className="p-2 text-gray-800">${order.totalCost.toFixed(2)}</td>
                     <td className="p-2">
-                      <button className=" text-white text-xs px-3 py-1 rounded trannsition-colors"
-                      style={{ 
-                          backgroundColor: '#6f597b'}}>
+                      <button 
+                        className="text-white text-xs px-3 py-1 rounded transition-colors"
+                        style={{ 
+                          backgroundColor: '#6f597b'
+                        }}
+                        
+                      >
                         Repurchase
                       </button>
                     </td>

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -176,9 +176,7 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
                         className="text-white text-xs px-3 py-1 rounded transition-colors"
                         style={{ 
                           backgroundColor: '#6f597b'
-                        }}
-                        
-                      >
+                        }}>
                         Repurchase
                       </button>
                     </td>

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -172,7 +172,9 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
                     <td className="p-2 text-gray-800">{order.quantity}</td>
                     <td className="p-2 text-gray-800">${order.totalCost.toFixed(2)}</td>
                     <td className="p-2">
-                      <button className="background-color:#6f596b bg-gray-500 text-white text-xs px-3 py-1 rounded hover:bg-gray-600 transition-colors">
+                      <button className=" text-white text-xs px-3 py-1 rounded trannsition-colors"
+                      style={{ 
+                          backgroundColor: '#6f597b'}}>
                         Repurchase
                       </button>
                     </td>

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from "react";
+import { Supplier } from "/imports/api/suppliers/SuppliersCollection";
+
+interface Order {
+  no: number;
+  date: string;
+  goods: string;
+  quantity: number;
+  totalCost: number;
+}
+
+interface SupplierInfoProps {
+  supplier: Supplier;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
+  const [sortBy, setSortBy] = useState<'date-desc' | 'date-asc'>('date-desc');
+  
+  
+  if (!supplier) return null;
+  if (!supplier.name) return null;
+  if (!supplier.email) return null;
+  if (!supplier.phone) return null;
+  if (!supplier.goods) supplier.goods = [];
+  if (!supplier.address) supplier.address = "";
+  if (!supplier.website) supplier.website = "";
+
+  // Note: Mock data for orders for Sprint 3 UI ONLY. 
+  // In sem 2, connect Data from Database, OrdersCollection..
+  const orderHistory: Order[] = [
+    {
+      no: 135,
+      date: "06/04/2025",
+      goods: "Coffee Beans- 1KG",
+      quantity: 20,
+      totalCost: 300.00
+    },
+    {
+      no: 134,
+      date: "06/03/2025",
+      goods: "Coffee Beans- 1KG",
+      quantity: 20,
+      totalCost: 300.00
+    },
+    {
+      no: 133,
+      date: "06/02/2025",
+      goods: "Coffee Beans- 1KG",
+      quantity: 20,
+      totalCost: 300.00
+    }
+  ];
+
+  const sortedOrders = [...orderHistory].sort((a, b) => {
+    const dateA = new Date(a.date).getTime();
+    const dateB = new Date(b.date).getTime();
+    return sortBy === 'date-desc' ? dateB - dateA : dateA - dateB;
+  });
+
+  if (!isExpanded) return null;
+
+  return (
+    <div className="bg-gray-100 p-6 mx-4 mb-4 rounded-lg border">
+      <div className="mb-4">
+        <h2 className="text-2xl font-bold text-gray-800 border-b-2 border-gray-300 pb-2">
+          {supplier.name}
+        </h2>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Contact Information */}
+        <div className="bg-white p-4 rounded-lg shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-700 mb-3 border-b border-gray-200 pb-2">
+            Contact
+          </h3>
+          <div className="space-y-2">
+            <div>
+              <span className="font-medium text-gray-600">Email:</span>
+              <a 
+                href={`mailto:${supplier.email}`}
+                className="ml-2 text-blue-600 hover:underline"
+              >
+                {supplier.email}
+              </a>
+            </div>
+            <div>
+              <span className="font-medium text-gray-600">Phone:</span>
+              <span className="ml-2 text-gray-800">{supplier.phone}</span>
+            </div>
+            <div>
+              {supplier.website && (
+                <div className="mb-2">
+                  <span className="font-medium text-gray-600">Website:</span>
+                  <a 
+                    href={supplier.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-2 text-blue-600 hover:underline"
+                  >
+                    {supplier.website}
+                  </a>
+                </div>
+              )}
+              {supplier.address && (
+                <div>
+                  <span className="font-medium text-gray-600">Address:</span>
+                  <div className="ml-2 text-gray-800">
+                    {supplier.address}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Supplier Goods */}
+        <div className="bg-white p-4 rounded-lg shadow-sm">
+          <h3 className="text-lg font-semibold text-gray-700 mb-3 border-b border-gray-200 pb-2 underline">
+            Supplier Goods
+          </h3>
+          <ul className="space-y-1">
+            {supplier.goods && supplier.goods.map((good, index) => (
+              <li key={index} className="flex items-center">
+                <span className="w-2 h-2 bg-gray-400 rounded-full mr-3"></span>
+                <span className="text-gray-800">{good}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Order History */}
+        <div className="bg-white p-4 rounded-lg shadow-sm lg:col-span-1">
+          <div className="flex justify-between items-center mb-3 border-b border-gray-200 pb-2">
+            <h3 className="text-lg font-semibold text-gray-700 underline">
+              Order History
+            </h3>
+            <div className="flex items-center space-x-2">
+              <span className="text-sm text-gray-600">Sort By:</span>
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as 'date-desc' | 'date-asc')}
+                className="text-sm text-blue-600 bg-transparent border-none cursor-pointer"
+              >
+                <option value="date-desc">Date (Descending)</option>
+                <option value="date-asc">Date (Ascending)</option>
+              </select>
+            </div>
+          </div>
+          
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200 rounded-l">No.</th>
+                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Date</th>
+                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Goods</th>
+                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200">Quantity</th>
+                  <th className="text-left p-2 font-medium text-gray-600 bg-red-200 rounded-r">
+                    Total Cost <span className="text-xs">(Inc GST)</span>
+                  </th>
+                  <th className="text-left p-2 font-medium text-gray-600"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedOrders.map((order, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    <td className="p-2 text-gray-800">{order.no}</td>
+                    <td className="p-2 text-gray-800">{order.date}</td>
+                    <td className="p-2 text-gray-800">{order.goods}</td>
+                    <td className="p-2 text-gray-800">{order.quantity}</td>
+                    <td className="p-2 text-gray-800">${order.totalCost.toFixed(2)}</td>
+                    <td className="p-2">
+                      <button className="background-color:#6f596b bg-gray-500 text-white text-xs px-3 py-1 rounded hover:bg-gray-600 transition-colors">
+                        Repurchase
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/imports/ui/components/SupplierTable.tsx
+++ b/imports/ui/components/SupplierTable.tsx
@@ -1,13 +1,20 @@
-import React from "react";
+import React, { useState } from "react";
 import { Supplier } from "/imports/api/suppliers/SuppliersCollection";
 import { InfoSymbol, Cross } from "./symbols/GeneralSymbols";
 import { Pill } from "./Pill";
+import { SupplierInfo } from "./SupplierInfo";
 
 interface SupplierTableProps {
   suppliers: Supplier[];
 }
 
 export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
+  const [expandedSupplierId, setExpandedSupplierId] = useState<string | null>(null);
+
+  const toggleExpanded = (supplierId: string) => {
+    setExpandedSupplierId(expandedSupplierId === supplierId ? null : supplierId);
+  };
+
   if (suppliers.length === 0)
     return (
       <h2 className="flex-1 text-center font-bold text-xl text-red-900">
@@ -38,14 +45,18 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
           PO
         </div>
         {suppliers.map((supplier, i) => {
+          const supplierId = supplier._id?.toString() || i.toString();
           return (
-            <React.Fragment key={i}>
+            <React.Fragment key={supplierId}>
               <div className="col-span-4 text-left truncate relative py-1 px-2 flex items-center">
                 <span className="truncate max-w-full px-1">
                   {supplier.name}
                 </span>
-                <span className="flex-shrink-0 ml-auto cursor-pointer">
-                  {<InfoSymbol fill="#E76573" viewBox="0 0 24 24" />}
+                <span 
+                  className="flex-shrink-0 ml-auto cursor-pointer"
+                  onClick={() => toggleExpanded(supplierId)}
+                >
+                  <InfoSymbol fill="#E76573" viewBox="0 0 24 24" />
                 </span>
                 <div className="absolute bg-amber-700/25 w-px h-3/4 end-0 bottom-1/8" />
               </div>
@@ -64,11 +75,11 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
                 <div className="absolute bg-amber-700/25 w-px h-3/4 end-0 bottom-1/8" />
               </div>
               <div className="col-span-3 flex flex-wrap relative py-1 px-2">
-                {supplier.goods.map((good) => (
-                  <span className="bg-rose-400 border-rose-300 text-white rounded-sm text-xs m-1 w-max h-max px-2 py-1 inline-flex items-center">
+                {supplier.goods && supplier.goods.map((good, goodIndex) => (
+                  <span key={goodIndex} className="bg-rose-400 border-rose-300 text-white rounded-sm text-xs m-1 w-max h-max px-2 py-1 inline-flex items-center">
                     {good}
                     <span className="pl-2 ml-auto cursor-pointer">
-                      {<Cross height="8px" width="8px" viewBox="0 0 14 14" />}
+                      <Cross height="8px" width="8px" viewBox="0 0 14 14" />
                     </span>
                   </span>
                 ))}
@@ -83,6 +94,17 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
                   Create PO
                 </button>
               </div>
+              
+              {/* Expandable Supplier Info */}
+              {expandedSupplierId === supplier._id?.toString() && (
+                <div className="col-span-15">
+                  <SupplierInfo
+                    supplier={supplier}
+                    isExpanded={true}
+                    onToggle={() => toggleExpanded(supplier._id?.toString() || '')}
+                  />
+                </div>
+              )}
             </React.Fragment>
           );
         })}

--- a/imports/ui/components/SupplierTable.tsx
+++ b/imports/ui/components/SupplierTable.tsx
@@ -12,7 +12,6 @@ interface SupplierTableProps {
 }
 
 export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
-  const [expandedSupplierId, setExpandedSupplierId] = useState<string | null>(null);
 
   const toggleExpanded = (supplierId: string) => {
     setExpandedSupplierId(expandedSupplierId === supplierId ? null : supplierId);
@@ -26,6 +25,7 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
     );
 
   const [isOpen, setIsOpen] = useState(false);
+  const [expandedSupplierId, setExpandedSupplierId] = useState<string | null>(null);
   const [purchaseOrderId, setPurchaseOrderId] = useState<Mongo.ObjectID>(
     new Mongo.ObjectID(),
   );


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86cyy3z1d

Added a container of detailed Supplier Information that is expandable by clicking on the info button next to Supplier Name. Added three columns which lists supplier contacts, goods and a table of past orders. 

Note: The data for supplier Purchase Orders are fixed and to be connected to database in next sprint. 

Changed heading colours to purple. 

<img width="368" alt="Screen Shot 2025-05-26 at 09 33 52" src="https://github.com/user-attachments/assets/37d4e901-2efe-4c7e-9c2a-2e3ac20fa222" />
<img width="1437" alt="Screen Shot 2025-05-26 at 09 33 29" src="https://github.com/user-attachments/assets/a7a6571f-0115-442b-8064-02ba1bf7e17d" />
