### PR TITLE
Fix some spacing and alignment in NavigationMenu

### DIFF
--- a/imports/ui/components/NavigationMenu.tsx
+++ b/imports/ui/components/NavigationMenu.tsx
@@ -95,7 +95,7 @@ const NavigationEntry = ({
       case NavigationEntrySelection.ARROW:
         return (
           <>
-            <div className="ps-3">{name}</div>
+            <div className="ps-3 content-center">{name}</div>
             <ArrowLeft />
           </>
         );
@@ -118,8 +118,8 @@ const NavigationEntry = ({
     <div className="flex flex-col text-nowrap truncate">
       <Link to={path}>
         <div className="flex flex-row text-press-up-grey border-b-[0.15em] border-press-up-grey min-w-full items mb-2">
-          <div className="flex-0">{icon}</div>
-          {active ? <ActiveContent /> : <div className="px-3">{name}</div>}
+          <div className="flex-0 content-center">{icon}</div>
+          {active ? <ActiveContent /> : <div className="px-3 content-center">{name}</div>}
         </div>
       </Link>
       <div className="grid grid-cols-12 text-[0.8em]">

--- a/imports/ui/components/symbols/navigation/Coffee.tsx
+++ b/imports/ui/components/symbols/navigation/Coffee.tsx
@@ -3,9 +3,8 @@ import { SVGIcon, SVGProps } from "../SVGIcon";
 export const CoffeeIcon = (props: SVGProps) => {
   return (
     <SVGIcon
-      viewBox="0 0 32 32"
+      viewBox="0 0 18 32"
       fill="#a52836"
-      width="48px"
       height="40px"
       {...props}
     >


### PR DESCRIPTION
Minor changes to fix some spacing and alignment issues in the navigation bar

Before:
![zen_oWxiDjfwSQ](https://github.com/user-attachments/assets/8c7aaaa6-fe0d-4843-aab7-5d2e051de5fd)

After:
![zen_X0m4i9fcSa](https://github.com/user-attachments/assets/aa1d0cb9-4532-4855-975d-5ce96e9ac136)
