### PR TITLE
Feature/store current order

### DIFF
--- a/imports/api/mockData.ts
+++ b/imports/api/mockData.ts
@@ -142,4 +142,19 @@ export const mockDataGenerator = async ({
           paid: faker.datatype.boolean(),
           orderStatus: faker.helpers.arrayElement(Object.values(OrderStatus)) as OrderStatus,
           createdAt: faker.date.recent({ days: 7 }),
-})}};
+})};
+
+    // Ensure Table 1 order exists (empty)
+    const table1 = await OrdersCollection.findOneAsync({ tableNo: 1 });
+    if (!table1) {
+      await OrdersCollection.insertAsync({
+        orderNo: 1,
+        tableNo: 1,
+        menuItems: [],
+        totalPrice: 0,
+        paid: false,
+        orderStatus: OrderStatus.Pending,
+        createdAt: new Date(),
+      });
+    }
+};

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -1,0 +1,14 @@
+import { Meteor } from "meteor/meteor";
+import { OrdersCollection } from "./OrdersCollection";
+import { Mongo } from "meteor/mongo";
+
+Meteor.methods({
+  async "orders.updateOrder"(orderId: Mongo.ObjectID, update: Partial<any>) {
+    if (!orderId || !update) throw new Meteor.Error("invalid-arguments", "Order ID and update are required");
+    await OrdersCollection.updateAsync(orderId, { $set: update });
+  },
+  async "orders.addOrder"(order: any) {
+    if (!order) throw new Meteor.Error("invalid-arguments", "Order data is required");
+    return OrdersCollection.insertAsync(order);
+  },
+});

--- a/imports/api/serverImports.ts
+++ b/imports/api/serverImports.ts
@@ -8,3 +8,4 @@ import "./orders/ordersPublishing";
 import "./suppliers/SupplierMethods";
 import "./purchaseOrders/purchaseOrdersMethods.ts";
 import "./purchaseOrders/purchaseOrdersPublishing.ts";
+import "./orders/ordersMethods";

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -2,6 +2,8 @@ import React , { useState, useEffect } from "react";
 import { MenuItem } from "/imports/api";
 import { PaymentModal } from "./PaymentModal";
 import { Mongo } from "meteor/mongo";
+import { useTracker } from "meteor/react-meteor-data";
+import { Order, OrdersCollection } from '/imports/api';
 
 
 interface PosSideMenuProps {
@@ -13,9 +15,11 @@ interface PosSideMenuProps {
   onDecrease: (itemId: Mongo.ObjectID) => void;
   onDelete: (itemId: Mongo.ObjectID) => void; 
   onUpdateOrder?: (fields: any) => void;
+  selectedTable: number;
+  setSelectedTable: (tableNo: number) => void;
 }
 
-export const PosSideMenu = ({ tableNo, items, total, orderId, onIncrease, onDecrease, onDelete, onUpdateOrder }: PosSideMenuProps) => {
+export const PosSideMenu = ({ tableNo, items, total, orderId, onIncrease, onDecrease, onDelete, onUpdateOrder, selectedTable, setSelectedTable }: PosSideMenuProps) => {
   const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
   const [discountPercent, setDiscountPercent] = useState(0)
   const [savedAmount, setSavedAmount] = useState(0)
@@ -41,11 +45,30 @@ export const PosSideMenu = ({ tableNo, items, total, orderId, onIncrease, onDecr
     onDelete(itemId);
   };
 
+  // Fetch all orders for dropdown
+  const orders: Order[] = useTracker(() => OrdersCollection.find({}, { sort: { tableNo: 1 } }).fetch());
+
+  // Handler for table change
+  const handleTableChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = parseInt(e.target.value, 10);
+    setSelectedTable(selected); // update parent state
+  };
+
   return (
     <div className="w-96 h-140 bg-gray-100 flex flex-col">
       <div className="flex items-center justify-between bg-rose-400 text-white px-4 py-2 rounded-t-md">
         <button className="text-2xl font-bold">⋯</button>
-        <span className="text-lg font-semibold">Table {tableNo}</span>
+        <select
+          className="text-lg font-semibold bg-rose-400 text-white border-none outline-none"
+          value={selectedTable}
+          onChange={handleTableChange}
+        >
+          {orders.map((order: Order) => (
+            <option key={String(order._id)} value={order.tableNo}>
+              Table {order.tableNo}
+            </option>
+          ))}
+        </select>
         <button className="text-2xl font-bold">×</button>
       </div>
 

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -8,12 +8,14 @@ interface PosSideMenuProps {
   tableNo: number;
   items: MenuItem[];
   total: number;
+  orderId?: string;
   onIncrease: (itemId: Mongo.ObjectID) => void;
   onDecrease: (itemId: Mongo.ObjectID) => void;
   onDelete: (itemId: Mongo.ObjectID) => void; 
+  onUpdateOrder?: (fields: any) => void;
 }
 
-export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease, onDelete }: PosSideMenuProps) => {
+export const PosSideMenu = ({ tableNo, items, total, orderId, onIncrease, onDecrease, onDelete, onUpdateOrder }: PosSideMenuProps) => {
   const [openDiscountPopup, setOpenDiscountPopup] = useState(false)
   const [discountPercent, setDiscountPercent] = useState(0)
   const [savedAmount, setSavedAmount] = useState(0)
@@ -29,6 +31,10 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease, onD
   const applyDiscount = (percentage: number) => {
     setDiscountPercent(percentage);
     setOpenDiscountPopup(false);
+    if (onUpdateOrder && orderId) {
+      const discountedTotal = total - (total * (percentage / 100));
+      onUpdateOrder({ discountPercent: percentage, totalPrice: parseFloat(discountedTotal.toFixed(2)) });
+    }
   };
 
   const handleDelete = (itemId: Mongo.ObjectID) => {
@@ -120,6 +126,9 @@ export const PosSideMenu = ({ tableNo, items, total, onIncrease, onDecrease, onD
             onClick={() => {
               setDiscountPercent(0);
               setSavedAmount(0);
+              if (onUpdateOrder && orderId) {
+                onUpdateOrder({ discountPercent: 0, totalPrice: total });
+              }
             }}
           >
             Reset

--- a/imports/ui/pages/pos/MainDisplay.js
+++ b/imports/ui/pages/pos/MainDisplay.js
@@ -8,7 +8,7 @@ import { useState } from "react";
 export const MainDisplay = () => {
     const [searchTerm, setSearchTerm] = useState("");
     const [selectedCategories, setSelectedCategories] = useState([]);
-    const [selectedTable, setSelectedTable] = useState(1); // NEW: selected table state
+    const [selectedTable, setSelectedTable] = useState(1);
     const isLoadingPosItems = useSubscribe("menuItems");
     const isLoadingOrders = useSubscribe("orders");
     const posItems = useTracker(() => MenuItemsCollection.find().fetch());
@@ -56,6 +56,14 @@ export const MainDisplay = () => {
       const updatedItems = order.menuItems.filter(i => i._id !== itemId);
       const newTotal = updatedItems.reduce((sum, i) => sum + i.quantity * i.price, 0);
       updateOrderInDb({ menuItems: updatedItems, totalPrice: parseFloat(newTotal.toFixed(2)) });
+    };
+
+    const toggleCategory = (category) => {
+      if (selectedCategories.includes(category)) {
+        setSelectedCategories(selectedCategories.filter((c) => c !== category));
+      } else {
+        setSelectedCategories([...selectedCategories, category]);
+      }
     };
 
     const handleItemClick = (item) => {

--- a/imports/ui/pages/pos/MainDisplay.js
+++ b/imports/ui/pages/pos/MainDisplay.js
@@ -8,11 +8,12 @@ import { useState } from "react";
 export const MainDisplay = () => {
     const [searchTerm, setSearchTerm] = useState("");
     const [selectedCategories, setSelectedCategories] = useState([]);
+    const [selectedTable, setSelectedTable] = useState(1); // NEW: selected table state
     const isLoadingPosItems = useSubscribe("menuItems");
     const isLoadingOrders = useSubscribe("orders");
     const posItems = useTracker(() => MenuItemsCollection.find().fetch());
-    // Fetch the current order for table 1 (hardcoded for now)
-    const order = useTracker(() => OrdersCollection.findOne({ tableNo: 1 }), []);
+    // Fetch the current order for the selected table
+    const order = useTracker(() => OrdersCollection.findOne({ tableNo: selectedTable }), [selectedTable]);
 
     const filteredItems = posItems.filter((item) => {
       const matchesName = item.name.toLowerCase().includes(searchTerm.toLowerCase());
@@ -139,7 +140,7 @@ export const MainDisplay = () => {
       {/* Side Panel */}
       <div id="pos-side-panel" className="p-4">
         <PosSideMenu
-          tableNo={order?.tableNo || 1}
+          tableNo={order?.tableNo || selectedTable}
           items={order?.menuItems || []}
           total={order?.totalPrice || 0}
           orderId={order?._id}
@@ -147,6 +148,8 @@ export const MainDisplay = () => {
           onDecrease={handleDecrease}
           onDelete={handleDelete}
           onUpdateOrder={updateOrderInDb}
+          selectedTable={selectedTable} // pass down
+          setSelectedTable={setSelectedTable} // pass down
         />
       </div>
     </div>


### PR DESCRIPTION
New:
- Orders on the POS display are now stored as database entries, which are automatically updated after any changes.
- When the page is loaded, the first Order is automatically selected on the side menu, based on table number in numerical order.
- Clicking the table label at the top of the side menu opens a dropdown menu to select a table that has a pre-existing order.
- Added hover highlights to + and - buttons on items.
- Removed faker data for orders. Now only randomises unique table numbers.

Bugs:
- On initial load of the page, the selected order is not displayed and cannot be edited. At the moment, a different order must be selected, then the initial order can be viewed and edited properly if switched back to it.

Dropdown View:
![image](https://github.com/user-attachments/assets/1832ac45-db23-4eca-b8c6-b026e86b0995)
