### PR TITLE
Feature/kitchen mgmt dashboard UI

### DIFF
--- a/imports/api/orders/OrdersCollection.ts
+++ b/imports/api/orders/OrdersCollection.ts
@@ -14,7 +14,7 @@ export interface OrderMenuItem {
 export interface Order extends DBEntry {
     orderNo: number;
     tableNo: number;
-    menuItems: OrderMenuItem[];
+    menuItems: string[];
     totalPrice: number;
     discountedPrice?: number;
     discountPercent?: number;

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -4,7 +4,7 @@ import { Mongo } from "meteor/mongo";
 import { requireLoginMethod } from "../accounts/wrappers";
 
 Meteor.methods({
-  "orders.updateOrder": requireLoginMethod(async function (orderId: Mongo.ObjectID, update: Partial<any>) {
+  "orders.updateOrder": requireLoginMethod(async function (orderId: string, update: Partial<any>) {
     if (!orderId || !update) throw new Meteor.Error("invalid-arguments", "Order ID and update are required");
     await OrdersCollection.updateAsync(orderId, { $set: update });
   }),

--- a/imports/ui/App.tsx
+++ b/imports/ui/App.tsx
@@ -3,7 +3,7 @@ import { RootPage } from "./pages/Root";
 import { StockPage } from "./pages/inventory/Stock";
 import { SuppliersPage } from "./pages/inventory/Suppliers";
 import { Menu } from "./pages/menuManagement/Menu";
-
+import { KitchenManagement } from "./pages/kitchenManagement/KitchenManagement";
 // pos system
 import { MainDisplay } from "./pages/pos/MainDisplay";
 import { PosIndex } from "./pages/pos/Index";
@@ -36,6 +36,10 @@ const router = createBrowserRouter([
       {
         path: "menuManagement",
         Component: Menu,
+      },
+      {
+        path: "kitchenManagement",
+        Component: KitchenManagement,
       },
       {
         path: "receipt",

--- a/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
@@ -1,0 +1,14 @@
+export type OrderStatus = 'NEW_ORDERS' | 'IN_PROGRESS' | 'READY' | 'COMPLETED';
+
+export type Order = {
+  orderNo: number;
+  status: OrderStatus;
+  tableNo: number;
+  menuItems: string[];
+  createdAt: string;
+};
+
+export type Column = {
+  id: OrderStatus;
+  title: string;
+};

--- a/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
@@ -1,6 +1,6 @@
 export type OrderStatus = "pending" | "preparing" | "ready" | "served";
 
-export type Order = {
+export type UiOrder = {
   _id: string; 
   orderNo: number;
   status: OrderStatus;

--- a/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
@@ -1,6 +1,7 @@
-export type OrderStatus = 'NEW_ORDERS' | 'IN_PROGRESS' | 'READY' | 'COMPLETED';
+export type OrderStatus = "pending" | "preparing" | "ready" | "served";
 
 export type Order = {
+  _id: string; 
   orderNo: number;
   status: OrderStatus;
   tableNo: number;

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -1,0 +1,16 @@
+import type { Order } from "./KitchenMgmtTypes";
+
+type OrderCardProps = {
+  order: Order;
+};
+
+
+export const OrderCard = ({order}: OrderCardProps) => {
+ 
+  return (
+    <div className="cursor-grab rounded-lg bg-neutral-700 p-4 shadow-sm hover:shadow-md">
+      <h3 className="font-medium text-neutral-100">{order.orderNo}</h3>
+      <p className="mt-2 text-sm text-neutral-400">{order.menuItems.join(", ")}</p>
+    </div>
+  );
+};

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -1,15 +1,15 @@
 import { useDraggable } from "@dnd-kit/core";
-import type { Order } from "./KitchenMgmtTypes";
+import type { UiOrder } from "./KitchenMgmtTypes";
 
 type OrderCardProps = {
-  order: Order;
+  order: UiOrder;
 };
 
 
 export const OrderCard = ({order}: OrderCardProps) => {
 
   const {attributes, listeners, setNodeRef, transform} = useDraggable({
-    id: order.orderNo,
+    id: order._id, 
   });
 
   const style = {

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -1,3 +1,4 @@
+import { useDraggable } from "@dnd-kit/core";
 import type { Order } from "./KitchenMgmtTypes";
 
 type OrderCardProps = {
@@ -6,9 +7,23 @@ type OrderCardProps = {
 
 
 export const OrderCard = ({order}: OrderCardProps) => {
- 
+
+  const {attributes, listeners, setNodeRef, transform} = useDraggable({
+    id: order.orderNo,
+  });
+
+  const style = {
+    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+  };
+
   return (
-    <div className="cursor-grab rounded-lg bg-neutral-700 p-4 shadow-sm hover:shadow-md">
+    <div 
+      ref={setNodeRef} 
+      {...listeners} 
+      {...attributes} 
+      className="cursor-grab rounded-lg bg-neutral-700 p-4 shadow-sm hover:shadow-md" 
+      style={style}
+    >
       <h3 className="font-medium text-neutral-100">{order.orderNo}</h3>
       <p className="mt-2 text-sm text-neutral-400">{order.menuItems.join(", ")}</p>
     </div>

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -21,11 +21,17 @@ export const OrderCard = ({order}: OrderCardProps) => {
       ref={setNodeRef} 
       {...listeners} 
       {...attributes} 
-      className="cursor-grab rounded-lg bg-neutral-700 p-4 shadow-sm hover:shadow-md" 
+      className="cursor-grab rounded-lg bg-white p-4 shadow-sm hover:shadow-md border-press-up-purple border-3" 
       style={style}
     >
-      <h3 className="font-medium text-neutral-100">{order.orderNo}</h3>
-      <p className="mt-2 text-sm text-neutral-400">{order.menuItems.join(", ")}</p>
+      <h3 className="font-medium text-press-up-purple text-xl">Order #{order.orderNo}</h3>
+      <p className="font-bold text-lg  text-press-up-purple">Table {order.tableNo}</p>
+      <p className="text-sm text-press-up-purple">{order.createdAt}</p>
+      <ul className="mt-3 list-disc list-inside text-lg text-press-up-purple">
+        {order.menuItems.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -28,9 +28,13 @@ export const OrderCard = ({order}: OrderCardProps) => {
       <p className="font-bold text-lg  text-press-up-purple">Table {order.tableNo}</p>
       <p className="text-sm text-press-up-purple">{order.createdAt}</p>
       <ul className="mt-3 list-disc list-inside text-lg text-press-up-purple">
-        {order.menuItems.map((item, index) => (
-          <li key={index}>{item}</li>
-        ))}
+        {Array.isArray(order.menuItems) && order.menuItems.length > 0 ? (
+          order.menuItems.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))
+        ) : (
+          <li className="italic text-sm text-press-up-purple">No items</li>
+        )}
       </ul>
     </div>
   );

--- a/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
@@ -1,0 +1,21 @@
+import type { Order, Column as ColumnType } from "./KitchenMgmtTypes";
+import { OrderCard } from "./OrderCard";
+
+type ColumnProps = {
+  column: ColumnType;
+  orders: Order[];
+};
+
+export const Column = ({column, orders}: ColumnProps) => {
+ 
+  return (
+    <div className="flex w-80 flex-col rounded-lg bg-neutral-800 p-4">
+      <h2 className="mb-4 font-semibold text-neutral-100">{column.title}</h2>
+      <div className="flex flex-1 flex-col gap-4">
+        {orders.map(order => {
+          return (<OrderCard key={order.orderNo} order={order} />);
+        })}
+      </div>
+    </div>
+  );
+};

--- a/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
@@ -1,3 +1,4 @@
+import { useDroppable } from "@dnd-kit/core";
 import type { Order, Column as ColumnType } from "./KitchenMgmtTypes";
 import { OrderCard } from "./OrderCard";
 
@@ -7,11 +8,15 @@ type ColumnProps = {
 };
 
 export const Column = ({column, orders}: ColumnProps) => {
- 
+
+  const {setNodeRef} = useDroppable({
+    id: column.id,
+  });
+
   return (
     <div className="flex w-80 flex-col rounded-lg bg-neutral-800 p-4">
       <h2 className="mb-4 font-semibold text-neutral-100">{column.title}</h2>
-      <div className="flex flex-1 flex-col gap-4">
+      <div ref={setNodeRef} className="flex flex-1 flex-col gap-4">
         {orders.map(order => {
           return (<OrderCard key={order.orderNo} order={order} />);
         })}

--- a/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
@@ -1,10 +1,10 @@
 import { useDroppable } from "@dnd-kit/core";
-import type { Order, Column as ColumnType } from "./KitchenMgmtTypes";
+import type { UiOrder, Column as ColumnType } from "./KitchenMgmtTypes";
 import { OrderCard } from "./OrderCard";
 
 type ColumnProps = {
   column: ColumnType;
-  orders: Order[];
+  orders: UiOrder[];
 };
 
 export const Column = ({column, orders}: ColumnProps) => {

--- a/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderStatusColumns.tsx
@@ -14,8 +14,8 @@ export const Column = ({column, orders}: ColumnProps) => {
   });
 
   return (
-    <div className="flex w-80 flex-col rounded-lg bg-neutral-800 p-4">
-      <h2 className="mb-4 font-semibold text-neutral-100">{column.title}</h2>
+    <div className="flex w-100 flex-col rounded-lg bg-press-up-light-purple p-4">
+      <h2 className="mb-4 font-semibold text-press-up-purple text-3xl">{column.title}</h2>
       <div ref={setNodeRef} className="flex flex-1 flex-col gap-4">
         {orders.map(order => {
           return (<OrderCard key={order.orderNo} order={order} />);

--- a/imports/ui/components/NavigationMenu.tsx
+++ b/imports/ui/components/NavigationMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "./symbols/navigation/Inventory";
 import { MonitorIcon } from "./symbols/navigation/POS";
 import { CoffeeIcon } from "./symbols/navigation/Coffee";
+import { Clock3, Clock3Icon, ClockIcon, TimerIcon } from "lucide-react";
 
 interface NavigationMenuProps {
   show: boolean;
@@ -56,6 +57,12 @@ export const NavigationMenu = ({ show }: NavigationMenuProps) => {
           icon={<CoffeeIcon fill="var(--color-press-up-grey)" />}
           name="Menu Management"
           path="/menuManagement"
+          selectionType={NavigationEntrySelection.HIGHLIGHT}
+        ></NavigationEntry>
+        <NavigationEntry
+          icon={<Clock3Icon />}
+          name="Kitchen Management"
+          path="/kitchenManagement"
           selectionType={NavigationEntrySelection.HIGHLIGHT}
         ></NavigationEntry>
       </div>

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+import { usePageTitle } from "../../hooks/PageTitleContext";
+import Sidebar from "../../components/AddItemSidebar";
+
+export const Menu = () => {
+  // Set title
+  const [_, setPageTitle] = usePageTitle();
+  useEffect(() => {
+    setPageTitle("Kitchen Management");
+  }, [setPageTitle]);
+
+ 
+  return (
+    <div className="flex flex-1 overflow-auto">
+      {/* Sidebar positioned on the right */}
+      <Sidebar />
+    </div>
+  );
+};

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Meteor } from "meteor/meteor";
 import { usePageTitle } from "../../hooks/PageTitleContext";
 // import Sidebar from "../../components/AddItemSidebar";
-import type { Order, Column as ColumnType, OrderStatus }  from "../../components/KitchenMgmtComponents/KitchenMgmtTypes";
+import type { UiOrder, Column as ColumnType, OrderStatus }  from "../../components/KitchenMgmtComponents/KitchenMgmtTypes";
 import { Column } from "../../components/KitchenMgmtComponents/OrderStatusColumns";
 import { useTracker } from "meteor/react-meteor-data";
 import { OrdersCollection, Order as DBOrder, OrderMenuItem, OrderStatus as DBStatus } from "../../../api/orders/OrdersCollection";
@@ -75,18 +75,18 @@ export const KitchenManagement = () => {
   //     );
   //   };
 
-  const orders = useTracker(() => {
+  const orders: UiOrder[] = useTracker(() => {
     const handler = Meteor.subscribe("orders");
     if (!handler.ready()) return [];
   
     const docs = OrdersCollection.find().fetch();
   
-    return docs.map((doc: DBOrder): Order => ({
-      _id: doc._id as string, // ObjectID를 string으로 변환
+    return docs.map((doc: DBOrder): UiOrder => ({
+      _id: doc._id as string, 
       orderNo: doc.orderNo,
       tableNo: doc.tableNo,
       createdAt: new Date(doc.createdAt).toLocaleTimeString().toUpperCase(),
-      status: doc.orderStatus as OrderStatus, // 변환 없이 직접 사용
+      status: doc.orderStatus as OrderStatus, 
       menuItems: doc.menuItems.map((item: OrderMenuItem) => item.name),
     }));
   }, []);
@@ -98,13 +98,12 @@ export const KitchenManagement = () => {
       const { active, over } = event;
       if (!over) return;
     
-      const orderNo = active.id as number;
+      const orderId = active.id as string; 
       const newStatus = over.id as ColumnType["id"];
     
       const newDbStatus = newStatus;
     
-      // 해당 order를 찾아서 _id 얻기 (중요!)
-      const order = OrdersCollection.findOne({ orderNo });
+      const order = OrdersCollection.findOne({ _id: orderId });
       if (!order) return;
     
       Meteor.call("orders.updateOrder", order._id, {

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -3,6 +3,7 @@ import { usePageTitle } from "../../hooks/PageTitleContext";
 import Sidebar from "../../components/AddItemSidebar";
 import type { Order, Column as ColumnType } from "../../components/KitchenMgmtComponents/KitchenMgmtTypes";
 import { Column } from "../../components/KitchenMgmtComponents/OrderStatusColumns";
+import { DndContext, DragEndEvent } from "@dnd-kit/core";
 
 const COLUMNS: ColumnType[] = [
   { id: 'NEW_ORDERS', title: 'New Orders' },
@@ -43,20 +44,40 @@ export const KitchenManagement = () => {
   }, [setPageTitle]);
 
   const [orders, setOrders] = useState<Order[]>(INITIAL_ORDERS);
+
+
+    const handleDragEnd = (event: DragEndEvent) => {
+      const { active, over } = event;
+
+      if (!over) return;
+
+      const orderNo = active.id as number;
+      const newStatus = over.id as Order['status'];
+
+      setOrders(() =>
+        orders.map((order) =>
+          order.orderNo === orderNo
+            ? { ...order, status: newStatus }
+            : order
+        )
+      );
+    };
+
  
   return (
     <div className="flex flex-1 overflow-auto">
       {/* Main content area */}
       <div className="p-4">
         <div className="flex gap-8">
-          {COLUMNS.map((column) => {
-            return (
-              <Column key={column.id} column={column} orders={orders.filter(order => order.status === column.id)} />
-            );
-          })}
+          <DndContext onDragEnd={handleDragEnd}>
+            {COLUMNS.map((column) => {
+              return (
+                <Column key={column.id} column={column} orders={orders.filter(order => order.status === column.id)} />
+              );
+            })}
+          </DndContext>
         </div>
       </div>
-
     </div>
   );
 };

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -87,7 +87,7 @@ export const KitchenManagement = () => {
       tableNo: doc.tableNo,
       createdAt: new Date(doc.createdAt).toLocaleTimeString().toUpperCase(),
       status: doc.orderStatus as OrderStatus, 
-      menuItems: doc.menuItems.map((item: OrderMenuItem) => item.name),
+      menuItems: doc.menuItems,
     }));
   }, []);
 

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -5,7 +5,7 @@ import { usePageTitle } from "../../hooks/PageTitleContext";
 import type { UiOrder, Column as ColumnType, OrderStatus }  from "../../components/KitchenMgmtComponents/KitchenMgmtTypes";
 import { Column } from "../../components/KitchenMgmtComponents/OrderStatusColumns";
 import { useTracker } from "meteor/react-meteor-data";
-import { OrdersCollection, Order as DBOrder, OrderMenuItem, OrderStatus as DBStatus } from "../../../api/orders/OrdersCollection";
+import { OrdersCollection, Order as DBOrder } from "../../../api/orders/OrdersCollection";
 import { DndContext, DragEndEvent } from "@dnd-kit/core";
 
 const COLUMNS: ColumnType[] = [
@@ -15,65 +15,12 @@ const COLUMNS: ColumnType[] = [
   { id: 'served', title: 'Served' }, 
 ];
 
-
-// const INITIAL_ORDERS: Order[] = [
-//   {
-//     orderNo: 1,
-//     status: 'NEW_ORDERS',
-//     tableNo: 1,
-//     menuItems: ["Pizza", "Pasta"],
-//     createdAt: new Date().toLocaleTimeString().toUpperCase()
-//   },
-//   {
-//     orderNo: 2,
-//     status: 'IN_PROGRESS',
-//     tableNo: 2,
-//     menuItems: ["Burger", "Fries"],
-//     createdAt: new Date().toLocaleTimeString().toUpperCase()
-//   },
-//   {
-//     orderNo: 3,
-//     status: 'READY',
-//     tableNo: 3,
-//     menuItems: ["Salad"],
-//     createdAt: new Date().toLocaleTimeString().toUpperCase()
-//   },
-//   {
-//     orderNo: 4,
-//     status: 'READY',
-//     tableNo: 4,
-//     menuItems: ["Coffee", "Cake"],
-//     createdAt: new Date().toLocaleTimeString().toUpperCase()
-//   },
-// ];
-
-
 export const KitchenManagement = () => {
   // Set title
   const [_, setPageTitle] = usePageTitle();
   useEffect(() => {
     setPageTitle("Kitchen Management");
   }, [setPageTitle]);
-
-  // const [orders, setOrders] = useState<Order[]>(INITIAL_ORDERS);
-
-
-  //   const handleDragEnd = (event: DragEndEvent) => {
-  //     const { active, over } = event;
-
-  //     if (!over) return;
-
-  //     const orderNo = active.id as number;
-  //     const newStatus = over.id as Order['status'];
-
-  //     setOrders(() =>
-  //       orders.map((order) =>
-  //         order.orderNo === orderNo
-  //           ? { ...order, status: newStatus }
-  //           : order
-  //       )
-  //     );
-  //   };
 
   const orders: UiOrder[] = useTracker(() => {
     const handler = Meteor.subscribe("orders");
@@ -90,8 +37,6 @@ export const KitchenManagement = () => {
       menuItems: doc.menuItems,
     }));
   }, []);
-
-
 
 
     const handleDragEnd = (event: DragEndEvent) => {

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -33,6 +33,13 @@ const INITIAL_ORDERS: Order[] = [
     menuItems: ["Salad"],
     createdAt: new Date().toLocaleTimeString().toUpperCase()
   },
+  {
+    orderNo: 4,
+    status: 'READY',
+    tableNo: 4,
+    menuItems: ["Coffee", "Cake"],
+    createdAt: new Date().toLocaleTimeString().toUpperCase()
+  },
 ];
 
 

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -1,19 +1,62 @@
 import { useState, useEffect } from "react";
 import { usePageTitle } from "../../hooks/PageTitleContext";
 import Sidebar from "../../components/AddItemSidebar";
+import type { Order, Column as ColumnType } from "../../components/KitchenMgmtComponents/KitchenMgmtTypes";
+import { Column } from "../../components/KitchenMgmtComponents/OrderStatusColumns";
 
-export const Menu = () => {
+const COLUMNS: ColumnType[] = [
+  { id: 'NEW_ORDERS', title: 'New Orders' },
+  { id: 'IN_PROGRESS', title: 'In Progress' },
+  { id: 'READY', title: 'Ready' },
+];
+
+const INITIAL_ORDERS: Order[] = [
+  {
+    orderNo: 1,
+    status: 'NEW_ORDERS',
+    tableNo: 1,
+    menuItems: ["Pizza", "Pasta"],
+    createdAt: new Date().toLocaleString()
+  },
+  {
+    orderNo: 2,
+    status: 'IN_PROGRESS',
+    tableNo: 2,
+    menuItems: ["Burger", "Fries"],
+    createdAt: new Date().toLocaleString()
+  },
+  {
+    orderNo: 3,
+    status: 'READY',
+    tableNo: 3,
+    menuItems: ["Salad"],
+    createdAt: new Date().toLocaleString()
+  },
+];
+
+
+export const KitchenManagement = () => {
   // Set title
   const [_, setPageTitle] = usePageTitle();
   useEffect(() => {
     setPageTitle("Kitchen Management");
   }, [setPageTitle]);
 
+  const [orders, setOrders] = useState<Order[]>(INITIAL_ORDERS);
  
   return (
     <div className="flex flex-1 overflow-auto">
-      {/* Sidebar positioned on the right */}
-      <Sidebar />
+      {/* Main content area */}
+      <div className="p-4">
+        <div className="flex gap-8">
+          {COLUMNS.map((column) => {
+            return (
+              <Column key={column.id} column={column} orders={orders.filter(order => order.status === column.id)} />
+            );
+          })}
+        </div>
+      </div>
+
     </div>
   );
 };

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -17,21 +17,21 @@ const INITIAL_ORDERS: Order[] = [
     status: 'NEW_ORDERS',
     tableNo: 1,
     menuItems: ["Pizza", "Pasta"],
-    createdAt: new Date().toLocaleString()
+    createdAt: new Date().toLocaleTimeString().toUpperCase()
   },
   {
     orderNo: 2,
     status: 'IN_PROGRESS',
     tableNo: 2,
     menuItems: ["Burger", "Fries"],
-    createdAt: new Date().toLocaleString()
+    createdAt: new Date().toLocaleTimeString().toUpperCase()
   },
   {
     orderNo: 3,
     status: 'READY',
     tableNo: 3,
     menuItems: ["Salad"],
-    createdAt: new Date().toLocaleString()
+    createdAt: new Date().toLocaleTimeString().toUpperCase()
   },
 ];
 
@@ -68,7 +68,7 @@ export const KitchenManagement = () => {
     <div className="flex flex-1 overflow-auto">
       {/* Main content area */}
       <div className="p-4">
-        <div className="flex gap-8">
+        <div className="flex gap-10">
           <DndContext onDragEnd={handleDragEnd}>
             {COLUMNS.map((column) => {
               return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@babel/core": "^7.28.0",
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/runtime": "^7.28.2",
+        "@dnd-kit/core": "^6.3.1",
         "@faker-js/faker": "^9.9.0",
         "@tailwindcss/postcss": "^4.1.11",
         "imports": "^1.0.0",
@@ -343,6 +344,42 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@faker-js/faker": {
@@ -3620,6 +3657,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.28.0",
     "@babel/plugin-transform-react-jsx": "^7.27.1",
     "@babel/runtime": "^7.28.2",
+    "@dnd-kit/core": "^6.3.1",
     "@faker-js/faker": "^9.9.0",
     "@tailwindcss/postcss": "^4.1.11",
     "imports": "^1.0.0",


### PR DESCRIPTION
<img width="1843" height="739" alt="image" src="https://github.com/user-attachments/assets/8f72498a-eaba-47a8-900c-7342401744b0" />


Pull Request: Kitchen Management Page Integration with MongoDB Orders Collection

This PR aligns the Kitchen Management page with the Orders collection in our MongoDB database.

✅ Key Features Implemented:
Orders are displayed in four status columns: Pending, Preparing, Ready, and Served.

Each card displays:

1. Order number

2. Table number

3. Order time

4. List of menu items

Cards are draggable across columns.

When a card is moved to a different column, the corresponding order's status is updated in the MongoDB database.

⚠️ Note: MongoDB extensions (e.g. Compass or VSCode) may not reflect updates in real-time. Please manually refresh the data to confirm status changes.