### PR TITLE
Hotfix - Remove duplicate kitchen management

### DIFF
--- a/imports/ui/components/NavigationMenu.tsx
+++ b/imports/ui/components/NavigationMenu.tsx
@@ -134,12 +134,6 @@ export const NavigationMenu = ({ show }: NavigationMenuProps) => {
             selectionType={NavigationEntrySelection.ARROW}
           />
         </NavigationEntry>
-        <NavigationEntry
-          icon={<Clock3Icon />}
-          name="Kitchen Management"
-          path="/kitchenManagement"
-          selectionType={NavigationEntrySelection.HIGHLIGHT}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
- Removing duplicate Kitchen Management sidebar tab

Before:
<img width="452" height="250" alt="image" src="https://github.com/user-attachments/assets/5ac0c27b-1e30-437b-a404-8a634013c125" />

After:
<img width="452" height="249" alt="image" src="https://github.com/user-attachments/assets/cd76deac-44c6-47eb-993f-934cbd680c29" />

