### PR TITLE
Add take away feature into POS sysytem

### DIFF
--- a/imports/api/orders/OrdersCollection.ts
+++ b/imports/api/orders/OrdersCollection.ts
@@ -2,6 +2,8 @@ import { Mongo } from "meteor/mongo";
 import { DBEntry, OmitDB, IdType } from "../database";
 import { MenuItem } from "../menuItems/MenuItemsCollection";
 
+export type OrderType = "dine-in" | "takeaway";
+
 // OrderMenuItem reuses MenuItem shape but _id may be optional when created client-side
 export type OrderMenuItem = Omit<MenuItem, "_id"> & {
   _id?: IdType;
@@ -10,7 +12,8 @@ export type OrderMenuItem = Omit<MenuItem, "_id"> & {
 
 export interface Order extends DBEntry {
   orderNo: number;
-  tableNo: number;
+  tableNo?: number | null; // null for takeaway orders
+  orderType: OrderType;
   menuItems: OrderMenuItem[];
   totalPrice: number;
   originalPrice?: number;

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -148,7 +148,7 @@ export const OrderCard = ({ order }: OrderCardProps) => {
             Order #{order.orderNo}
           </h3>
           <p className="font-bold text-lg text-press-up-purple">
-            Table {order.tableNo}
+            {order.tableNo != null ? `Table ${order.tableNo}` : "Takeaway"}
           </p>
           <p className="text-sm text-press-up-purple">{order.createdAt}</p>
 
@@ -177,7 +177,8 @@ export const OrderCard = ({ order }: OrderCardProps) => {
             <strong>Order No:</strong> {order.orderNo}
           </p>
           <p>
-            <strong>Table No:</strong> {order.tableNo}
+            <strong>Table:</strong>{" "}
+            {order.tableNo != null ? order.tableNo : "Takeaway"}
           </p>
           <p>
             <strong>Created At:</strong> {order.createdAt}

--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -5,7 +5,7 @@ import { Order } from "/imports/api";
 import { OrderStatus } from "/imports/api/orders/OrdersCollection";
 
 interface PaymentModalProps {
-  tableNo: number;
+  tableNo?: number | null;
   order: Order;
 }
 

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -228,6 +228,7 @@ export const PosSideMenu = ({
     navigate(`${location.pathname}?${params.toString()}`);
   };
 
+
   return (
     <div className="w-64 h-[75vh] flex flex-col">
       {/* Header */}

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -228,6 +228,16 @@ export const PosSideMenu = ({
     navigate(`${location.pathname}?${params.toString()}`);
   };
 
+  const generateFourDigitOrderNo = (): number => {
+    for (let i = 0; i < 10; i++) { 
+      const candidate = Math.floor(1000 + Math.random() * 9000); // 1000~9999
+      const exists = OrdersCollection.findOne({ orderNo: candidate });
+      if (!exists) return candidate;
+    }
+    // Fallback (extremely unlikely) — still return a 4-digit number
+    return Math.floor(1000 + Math.random() * 9000);
+  };
+
 
   return (
     <div className="w-64 h-[75vh] flex flex-col">
@@ -368,7 +378,7 @@ export const PosSideMenu = ({
                       const orderId = await Meteor.callAsync(
                         "orders.addOrder",
                         {
-                          orderNo: Date.now(),
+                          orderNo: generateFourDigitOrderNo(),
                           tableNo: selectedTable,
                           menuItems: [],
                           totalPrice: 0,
@@ -463,12 +473,12 @@ export const PosSideMenu = ({
         {orderType === "takeaway" && (
           <button
             // full width, sits right under Discount button
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full mb-2"
+            className="w-full bg-orange-600 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded-full mb-2"
             onClick={async () => {
               try {
                 // create a fresh takeaway order
                 const newId = await Meteor.callAsync("orders.addOrder", {
-                  orderNo: Date.now(),
+                  orderNo: generateFourDigitOrderNo(),
                   orderType: "takeaway",
                   tableNo: null,
                   menuItems: [],

--- a/imports/ui/pages/pos/MainDisplay.tsx
+++ b/imports/ui/pages/pos/MainDisplay.tsx
@@ -25,6 +25,7 @@ export const MainDisplay = () => {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedTable, setSelectedTable] = useState<number | null>(null);
   const location = useLocation();
+  const [activeOrderId, setActiveOrderId] = useState<string | null>(null);
 
   useSubscribe("menuItems");
   useSubscribe("orders");
@@ -33,13 +34,17 @@ export const MainDisplay = () => {
   const tables = useTracker(() => TablesCollection.find().fetch());
   const posItems = useTracker(() => MenuItemsCollection.find().fetch());
   // Fetch the current order for the selected table
-  const order = useTracker(
-    () =>
-      selectedTable
-        ? OrdersCollection.find({ tableNo: selectedTable }).fetch()[0]
-        : null,
-    [selectedTable],
-  );
+  const order = useTracker(() => {
+    if (activeOrderId) {
+      return OrdersCollection.findOne(activeOrderId as any) ?? null;
+    }
+    return selectedTable
+      ? OrdersCollection.find({
+          tableNo: selectedTable,
+          $or: [{ orderType: "dine-in" }, { orderType: { $exists: false } }],
+        }).fetch()[0] ?? null
+      : null;
+  }, [activeOrderId, selectedTable]);
 
   const filteredItems = posItems.filter((item) => {
     const matchesName = item.name
@@ -303,6 +308,7 @@ export const MainDisplay = () => {
           onUpdateOrder={updateOrderInDb}
           selectedTable={selectedTable} // pass down
           setSelectedTable={setSelectedTable} // pass down
+          onActiveOrderChange={setActiveOrderId}  
         />
       </div>
     </div>


### PR DESCRIPTION
<img width="218" height="674" alt="image" src="https://github.com/user-attachments/assets/d062dac9-ad1b-4713-8fb2-19e420ec61f8" />
<img width="220" height="684" alt="image" src="https://github.com/user-attachments/assets/cd87856c-cb82-4e66-b2c4-ff4ca7a28631" />
<img width="311" height="212" alt="image" src="https://github.com/user-attachments/assets/4833aaed-46ed-49ef-9dad-86fb8dc56e5c" />
<img width="893" height="385" alt="image" src="https://github.com/user-attachments/assets/d9733311-8c7d-4406-ae2d-dd2d0c541c6d" />

Key Changes

1. Order Schema Update
Orders now include an orderType field, which can be either dine-in or takeaway.

2. Takeaway Order Creation
When “Start new order” is clicked under takeaway mode, the system generates a random 4-digit order number and creates a new takeaway order in the database.

3. Menu Item Integration
Once a takeaway order is created, menu item clicks correctly update the database, and the order is reflected in the Kitchen Management view just like dine-in orders.

4. Payment Workflow
After clicking the Pay button, takeaway orders are automatically set to served and removed from the active takeaway dropdown list.

Improvements

1. Payment Restrictions
Both dine-in and takeaway orders can no longer be paid while in pending or ready states.
Orders can only be paid when the status is explicitly set to served.
