### PR TITLE
Refactor Table & Order Management, Add Move Order Feature

### DIFF
--- a/imports/api/mockData.ts
+++ b/imports/api/mockData.ts
@@ -227,9 +227,16 @@ export const mockDataGenerator = async ({
   // Create tables first with no order assigned
   if ((await TablesCollection.countDocuments()) === 0) {
     for (let i = 1; i < tableCount + 1; ++i) {
-      const capacity = faker.number.int({ min: 1, max: 10 });
-      // Set 70% occupied, and 30% not occupied
-      const isOccupied = faker.datatype.boolean(0.7) ? true : false;
+      // const capacity = faker.number.int({ min: 1, max: 6 });
+      // // Set 70% occupied, and 30% not occupied
+      // const isOccupied = faker.datatype.boolean(0.7) ? true : false;
+      // // If occupied, set number of occupants from 1 to max capacity of table, otherwise, zero occupants
+      // const noOccupants = isOccupied
+      //   ? faker.number.int({ min: 1, max: capacity })
+      //   : 0;
+      const capacity = faker.number.int({ min: 1, max: 6 });
+      // Set every even table to be occupied
+      const isOccupied = (i%2==0) ? true : false;
       // If occupied, set number of occupants from 1 to max capacity of table, otherwise, zero occupants
       const noOccupants = isOccupied
         ? faker.number.int({ min: 1, max: capacity })

--- a/imports/api/mockData.ts
+++ b/imports/api/mockData.ts
@@ -255,11 +255,12 @@ export const mockDataGenerator = async ({
 
   // Create orders: mix of dine-in (linked to tables) and takeaway (no table)
   if ((await OrdersCollection.countDocuments()) === 0) {
-    const allTables = await TablesCollection.find(
-      {},
+    // Only select tables that are occupied
+    const allOccupiedTables = await TablesCollection.find(
+      { isOccupied: true },
       { fields: { tableNo: 1 } },
     ).fetchAsync();
-    const availableTableNos = allTables.map((t) => t.tableNo);
+    const availableTableNos = allOccupiedTables.map((t) => t.tableNo);
 
     const dineInCount = Math.max(
       0,

--- a/imports/api/mockData.ts
+++ b/imports/api/mockData.ts
@@ -236,7 +236,7 @@ export const mockDataGenerator = async ({
       //   : 0;
       const capacity = faker.number.int({ min: 1, max: 6 });
       // Set every even table to be occupied
-      const isOccupied = (i%2==0) ? true : false;
+      const isOccupied = i % 2 == 0 ? true : false;
       // If occupied, set number of occupants from 1 to max capacity of table, otherwise, zero occupants
       const noOccupants = isOccupied
         ? faker.number.int({ min: 1, max: capacity })
@@ -267,6 +267,9 @@ export const mockDataGenerator = async ({
       Math.min(orderCount!, availableTableNos.length),
     );
     const takeawayCount = Math.max(0, orderCount! - dineInCount);
+
+    // Start orderNo from 1001
+    let nextOrderNo = 1001;
 
     const genOrderMenuItems = async (): Promise<OrderMenuItem[]> => {
       const rawMenuItems = await MenuItemsCollection.rawCollection()
@@ -305,7 +308,7 @@ export const mockDataGenerator = async ({
       const total = items.reduce((sum, it) => sum + it.price * it.quantity, 0);
 
       const orderID = await OrdersCollection.insertAsync({
-        orderNo: faker.number.int({ min: 1000, max: 9999 }),
+        orderNo: nextOrderNo,
         orderType: "dine-in",
         tableNo,
         menuItems: items,
@@ -314,8 +317,9 @@ export const mockDataGenerator = async ({
         orderStatus: status,
         createdAt: new Date(
           Date.now() - faker.number.int({ min: 0, max: 25 * 60 }) * 1000,
-        ), // within last 25 minutes
+        ),
       });
+      nextOrderNo++;
 
       // Update the table with activeOrderID and push to orderIDs
       await TablesCollection.updateAsync(
@@ -333,7 +337,7 @@ export const mockDataGenerator = async ({
       const total = items.reduce((sum, it) => sum + it.price * it.quantity, 0);
 
       await OrdersCollection.insertAsync({
-        orderNo: faker.number.int({ min: 1000, max: 9999 }),
+        orderNo: nextOrderNo,
         orderType: "takeaway",
         tableNo: null,
         menuItems: items,
@@ -342,6 +346,7 @@ export const mockDataGenerator = async ({
         orderStatus: status,
         createdAt: faker.date.recent({ days: 7 }),
       });
+      nextOrderNo++;
     }
   }
 };

--- a/imports/api/mockData.ts
+++ b/imports/api/mockData.ts
@@ -237,7 +237,8 @@ export const mockDataGenerator = async ({
 
       await TablesCollection.insertAsync({
         tableNo: i,
-        orderID: null,
+        activeOrderID: null,
+        orderIDs: [],
         capacity: capacity,
         isOccupied: isOccupied,
         noOccupants: noOccupants,
@@ -308,9 +309,13 @@ export const mockDataGenerator = async ({
         ), // within last 25 minutes
       });
 
+      // Update the table with activeOrderID and push to orderIDs
       await TablesCollection.updateAsync(
         { tableNo },
-        { $set: { orderID: String(orderID) } },
+        {
+          $set: { activeOrderID: String(orderID) },
+          $push: { orderIDs: String(orderID) },
+        },
       );
     }
 

--- a/imports/api/orders/OrdersCollection.ts
+++ b/imports/api/orders/OrdersCollection.ts
@@ -23,7 +23,6 @@ export interface Order extends DBEntry {
   createdAt: Date;
   orderStatus: OrderStatus;
   paid: boolean;
-  seats?: number;
 }
 
 export enum OrderStatus {

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -18,17 +18,18 @@ Meteor.methods({
   }),
 
   "orders.addOrder": requireLoginMethod(async function (order: Partial<Order>) {
-  if (!order) throw new Meteor.Error("invalid-arguments", "Order data is required");
-  if (!order.orderNo) {
-    let candidate: number;
-    for (let i = 0; i < 10; i++) {
-      candidate = Math.floor(1000 + Math.random() * 9000);
-      if (!OrdersCollection.findOneAsync({ orderNo: candidate })) break;
+    if (!order)
+      throw new Meteor.Error("invalid-arguments", "Order data is required");
+    if (!order.orderNo) {
+      let candidate: number;
+      for (let i = 0; i < 10; i++) {
+        candidate = Math.floor(1000 + Math.random() * 9000);
+        if (!OrdersCollection.findOneAsync({ orderNo: candidate })) break;
+      }
+      order.orderNo = candidate!;
     }
-    order.orderNo = candidate!;
-  }
-  return await OrdersCollection.insertAsync(order as Order);
-}),
+    return await OrdersCollection.insertAsync(order as Order);
+  }),
 
   "orders.getAll": requireLoginMethod(async function () {
     return OrdersCollection.find().fetch();
@@ -56,5 +57,11 @@ Meteor.methods({
     return await OrdersCollection.updateAsync(orderId, {
       $set: { "menuItems.$[].served": served },
     });
+  }),
+
+  "orders.removeOrder": requireLoginMethod(async function (orderId: IdType) {
+    if (!orderId)
+      throw new Meteor.Error("invalid-arguments", "Order ID is required");
+    await OrdersCollection.removeAsync(orderId);
   }),
 });

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -17,11 +17,18 @@ Meteor.methods({
     await OrdersCollection.updateAsync(orderId, { $set: update });
   }),
 
-  "orders.addOrder": requireLoginMethod(async function (order: Order) {
-    if (!order)
-      throw new Meteor.Error("invalid-arguments", "Order data is required");
-    return await OrdersCollection.insertAsync(order);
-  }),
+  "orders.addOrder": requireLoginMethod(async function (order: Partial<Order>) {
+  if (!order) throw new Meteor.Error("invalid-arguments", "Order data is required");
+  if (!order.orderNo) {
+    let candidate: number;
+    for (let i = 0; i < 10; i++) {
+      candidate = Math.floor(1000 + Math.random() * 9000);
+      if (!OrdersCollection.findOneAsync({ orderNo: candidate })) break;
+    }
+    order.orderNo = candidate!;
+  }
+  return await OrdersCollection.insertAsync(order as Order);
+}),
 
   "orders.getAll": requireLoginMethod(async function () {
     return OrdersCollection.find().fetch();

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -21,12 +21,16 @@ Meteor.methods({
     if (!order)
       throw new Meteor.Error("invalid-arguments", "Order data is required");
     if (!order.orderNo) {
-      let candidate: number;
-      for (let i = 0; i < 10; i++) {
-        candidate = Math.floor(1000 + Math.random() * 9000);
-        if (!OrdersCollection.findOneAsync({ orderNo: candidate })) break;
+      // Find the highest existing orderNo and increment
+      const lastOrder = await OrdersCollection.find(
+        {},
+        { sort: { orderNo: -1 }, limit: 1 },
+      ).fetchAsync();
+      let nextOrderNo = 1;
+      if (lastOrder.length > 0 && typeof lastOrder[0].orderNo === "number") {
+        nextOrderNo = lastOrder[0].orderNo + 1;
       }
-      order.orderNo = candidate!;
+      order.orderNo = nextOrderNo;
     }
     return await OrdersCollection.insertAsync(order as Order);
   }),

--- a/imports/api/tables/TablesCollection.ts
+++ b/imports/api/tables/TablesCollection.ts
@@ -3,7 +3,8 @@ import { DBEntry, IdType, OmitDB } from "../database";
 
 export interface Tables extends DBEntry {
   tableNo: number;
-  orderID: IdType | null;
+  activeOrderID: IdType | null;
+  orderIDs: IdType[] | null;
   capacity: number;
   isOccupied: boolean;
   noOccupants?: number;

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -168,47 +168,49 @@ export const OrderCard = ({ order }: OrderCardProps) => {
         />
 
         <div className="cursor-pointer" onClick={() => setOpen(true)}>
-          <h3 className="font-medium text-press-up-purple text-xl">
-            Order #{order.orderNo}
-          </h3>
-          <p className="font-bold text-lg text-press-up-purple">
-            {order.tableNo != null ? `Table ${order.tableNo}` : "Takeaway"}
-          </p>
-          <p className="text-sm text-press-up-purple">{order.createdAt}</p>
+          <div className="flex items-center justify-between gap-2 w-full">
+            <h3 className="font-medium text-press-up-purple text-xl flex-1 min-w-0 truncate">
+              Order #{order.orderNo}
+            </h3>
 
-          <div className="mt-1">
-            <Chip
-              size="small"
-              label={`Waiting ${waitText}`}
-              title={new Date(createdMs).toLocaleString()}
-              sx={{
-                backgroundColor: waitColor,
-                color: "#fff",
-                fontWeight: 600,
-              }}
-            />
+            <div className="mt-1">
+              <Chip
+                size="small"
+                label={`Waiting ${waitText}`}
+                title={new Date(createdMs).toLocaleString()}
+                sx={{
+                  backgroundColor: waitColor,
+                  color: "#fff",
+                  fontWeight: 600,
+                }}
+              />
+            </div>
           </div>
-        </div>
 
-        <div>
-          <p className="font-bold text-lg text-press-up-purple">
-            Table {order.tableNo}
-          </p>
-          <p className="text-sm text-press-up-purple">{order.createdAt}</p>
-          <ul className="mt-3 list-disc list-inside text-lg text-press-up-purple">
-            {Array.isArray(order.menuItems) && order.menuItems.length > 0 ? (
-              order.menuItems.map((item, index) => (
-                <li key={index}>
-                  <span className="ml-2 text-base font-semibold">
-                    {item.quantity} x{" "}
-                  </span>
-                  {item.name}
+          <div>
+            <p className="font-bold text-lg text-press-up-purple">
+              {order.tableNo != null
+                ? `Table No: ${order.tableNo}`
+                : "Takeaway"}
+            </p>
+            <p className="text-sm text-press-up-purple">{order.createdAt}</p>
+            <ul className="mt-3 list-disc list-inside text-lg text-press-up-purple">
+              {Array.isArray(order.menuItems) && order.menuItems.length > 0 ? (
+                order.menuItems.map((item, index) => (
+                  <li key={index}>
+                    <span className="ml-2 text-base font-semibold">
+                      {item.quantity} x{" "}
+                    </span>
+                    {item.name}
+                  </li>
+                ))
+              ) : (
+                <li className="italic text-sm text-press-up-purple">
+                  No items
                 </li>
-              ))
-            ) : (
-              <li className="italic text-sm text-press-up-purple">No items</li>
-            )}
-          </ul>
+              )}
+            </ul>
+          </div>
         </div>
       </div>
 
@@ -224,8 +226,11 @@ export const OrderCard = ({ order }: OrderCardProps) => {
             <strong>Order No:</strong> {order.orderNo}
           </p>
           <p>
-            <strong>Table:</strong>{" "}
-            {order.tableNo != null ? order.tableNo : "Takeaway"}
+            <strong>
+              {order.tableNo != null
+                ? `Table No: ${order.tableNo}`
+                : "Takeaway"}
+            </strong>
           </p>
           <p>
             <strong>Created At:</strong> {order.createdAt}
@@ -299,6 +304,7 @@ export const OrderCard = ({ order }: OrderCardProps) => {
             )}
           </List>
 
+          {/* Status Dropdown */}
           <FormControl fullWidth sx={{ mt: 2 }}>
             <InputLabel>Status</InputLabel>
             <Select
@@ -309,6 +315,7 @@ export const OrderCard = ({ order }: OrderCardProps) => {
               <MenuItem value="pending">Pending</MenuItem>
               <MenuItem value="preparing">Preparing</MenuItem>
               <MenuItem value="ready">Ready</MenuItem>
+
               <MenuItem
                 value="served"
                 disabled={!(status === "ready" && allServed)}

--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Meteor } from "meteor/meteor";
 import { Order } from "/imports/api";
+import { TablesCollection } from "/imports/api/tables/TablesCollection";
 import { OrderStatus } from "/imports/api/orders/OrdersCollection";
 
 interface PaymentModalProps {
@@ -32,6 +33,15 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
       paid: true,
     };
     Meteor.call("orders.updateOrder", order._id, { ...fields });
+
+    // Clear the table's activeOrderID if this is a dine-in order
+    if (order.tableNo !== null && order.tableNo !== undefined) {
+      // Find the table by tableNo and clear its activeOrderID
+      Meteor.call(
+        "tables.clearOrder",
+        TablesCollection.findOne({ tableNo: order.tableNo })?._id,
+      );
+    }
   };
 
   const handleConfirm = () => {

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -239,16 +239,6 @@ export const PosSideMenu = ({
     navigate(`${location.pathname}?${params.toString()}`);
   };
 
-  const generateFourDigitOrderNo = (): number => {
-    for (let i = 0; i < 10; i++) {
-      const candidate = Math.floor(1000 + Math.random() * 9000); // 1000~9999
-      const exists = OrdersCollection.findOne({ orderNo: candidate });
-      if (!exists) return candidate;
-    }
-    // Fallback (extremely unlikely) — still return a 4-digit number
-    return Math.floor(1000 + Math.random() * 9000);
-  };
-
   return (
     <div className="w-64 h-[75vh] flex flex-col">
       {/* Header */}
@@ -386,7 +376,6 @@ export const PosSideMenu = ({
                       const orderId = await Meteor.callAsync(
                         "orders.addOrder",
                         {
-                          orderNo: generateFourDigitOrderNo(),
                           tableNo: selectedTable,
                           menuItems: [],
                           totalPrice: 0,
@@ -492,7 +481,6 @@ export const PosSideMenu = ({
               try {
                 // create a fresh takeaway order
                 const newId = await Meteor.callAsync("orders.addOrder", {
-                  orderNo: generateFourDigitOrderNo(),
                   orderType: "takeaway",
                   tableNo: null,
                   menuItems: [],

--- a/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
+++ b/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
@@ -33,6 +33,7 @@ type RowOrder = {
   createdAt: string;
   status: "pending" | "preparing" | "ready" | "served";
   items: string;
+  paid: boolean;
 };
 
 export const OrderHistoryPage = () => {
@@ -53,6 +54,7 @@ export const OrderHistoryPage = () => {
       items: (doc.menuItems ?? [])
         .map((mi) => `${mi.name} x${mi.quantity ?? 1}`)
         .join(", "),
+      paid: !!doc.paid,
     }));
   }, []);
 
@@ -165,6 +167,10 @@ export const OrderHistoryPage = () => {
                         },
                       }}
                       onClick={() => reopen(row._id, "ready")}
+                      disabled={
+                        // Prevent reopening if paid
+                        orders.find((o) => o._id === row._id)?.paid === true
+                      }
                     >
                       Reopen: Ready
                     </Button>
@@ -181,6 +187,10 @@ export const OrderHistoryPage = () => {
                         },
                       }}
                       onClick={() => reopen(row._id, "preparing")}
+                      disabled={
+                        // Prevent reopening if paid
+                        orders.find((o) => o._id === row._id)?.paid === true
+                      }
                     >
                       Reopen: Preparing
                     </Button>

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -429,7 +429,9 @@ export const TablesPage = () => {
                       }
                       if (idx !== -1) {
                         // Find the smallest available table number
-                        const usedTableNos = grid.filter((t) => t !== null).map((t) => t!.tableNo);
+                        const usedTableNos = grid
+                          .filter((t) => t !== null)
+                          .map((t) => t!.tableNo);
                         let nextTableNo = 1;
                         while (usedTableNos.includes(nextTableNo)) {
                           nextTableNo++;
@@ -726,7 +728,10 @@ export const TablesPage = () => {
                             { tableNo: newTable.tableNo },
                           );
                           // Re-render by updating grid from DB
-                          const refreshedTables = TablesCollection.find({}, { sort: { tableNo: 1 } }).fetch();
+                          const refreshedTables = TablesCollection.find(
+                            {},
+                            { sort: { tableNo: 1 } },
+                          ).fetch();
                           const newGrid = Array(GRID_SIZE).fill(null);
                           refreshedTables.forEach((table, idx) => {
                             if (idx < GRID_SIZE) {
@@ -926,7 +931,10 @@ export const TablesPage = () => {
                       if (dbTable && dbTable._id) {
                         // Clear order from kitchen management if table has an active order
                         if (dbTable.activeOrderID) {
-                          await Meteor.callAsync("orders.removeOrder", dbTable.activeOrderID);
+                          await Meteor.callAsync(
+                            "orders.removeOrder",
+                            dbTable.activeOrderID,
+                          );
                         }
                         await Meteor.callAsync(
                           "tables.removeTable",

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -540,6 +540,7 @@ export const TablesPage = () => {
                             {
                               // orderNo is now auto-generated server-side
                               tableNo: editTableData!.tableNo,
+                              orderType: "dine-in",
                               menuItems: [],
                               totalPrice: 0,
                               createdAt: new Date(),

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -592,54 +592,53 @@ export const TablesPage = () => {
                     Add Order
                   </button>
 
-                  {/* Occupied toggle */}
-                  <button
-                    onClick={() => {
-                      const newOccupied = !occupiedToggle;
-                      // if we're marking vacant and there's an existing order, confirm first
-                      const dbTable = tablesFromDb.find(
-                        (t) => t.tableNo === editTableData!.tableNo,
-                      );
-                      const hasOrder = !!(
-                        dbTable?.activeOrderID ||
-                        editTableData?.activeOrderID ||
-                        modalOriginalTable?.activeOrderID
-                      );
-                      if (!newOccupied && hasOrder) {
-                        setConfirmMsg(
-                          "This will remove the linked order and mark the table as vacant. Continue?",
-                        );
-                        setConfirmAction(() => () => {
+                  {/* Occupied/Vacant Toggle */}
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!occupiedToggle) {
+                          setOccupiedToggle(true);
+                          setOccupancyInput(occupancyInput || "1");
+                        } else {
+                          // If marking vacant and there's an active order, confirm
+                          const dbTable = tablesFromDb.find(
+                            (t) => t.tableNo === editTableData!.tableNo,
+                          );
+                          const hasOrder = !!(
+                            dbTable?.activeOrderID ||
+                            editTableData?.activeOrderID ||
+                            modalOriginalTable?.activeOrderID
+                          );
+                          if (hasOrder) {
+                            setConfirmMsg(
+                              "This will remove the linked order and mark the table as vacant. Continue?",
+                            );
+                            setConfirmAction(() => () => {
+                              setOccupiedToggle(false);
+                              setOccupancyInput("");
+                              setClearOrderOnSave(true);
+                              setConfirmOpen(false);
+                            });
+                            setConfirmOpen(true);
+                            return;
+                          }
                           setOccupiedToggle(false);
                           setOccupancyInput("");
-                          setClearOrderOnSave(true);
-                          setConfirmOpen(false);
-                        });
-                        setConfirmOpen(true);
-                        return;
-                      }
-                      setOccupiedToggle(newOccupied);
-                      if (!newOccupied) {
-                        // hide/clear occupancy input when marking vacant
-                        setOccupancyInput("");
-                        setClearOrderOnSave(false);
-                      } else if (!occupancyInput) {
-                        // default to 1 occupant when marking occupied and no value present
-                        setOccupancyInput("1");
-                        setClearOrderOnSave(false);
-                      }
-                    }}
-                    aria-pressed={occupiedToggle}
-                    aria-label={occupiedToggle ? "Set Vacant" : "Set Occupied"}
-                    style={{
-                      backgroundColor: occupiedToggle ? "#c97f97" : "#6f597b",
-                      color: "#fff",
-                      minWidth: 110,
-                    }}
-                    className="px-4 py-1 rounded"
-                  >
-                    {occupiedToggle ? "Occupied" : "Vacant"}
-                  </button>
+                        }
+                      }}
+                      className={`px-4 py-1 rounded font-semibold transition-colors duration-300 ${
+                        occupiedToggle
+                          ? "bg-press-up-purple text-white"
+                          : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                      }`}
+                      aria-pressed={occupiedToggle}
+                      aria-label={occupiedToggle ? "Occupied" : "Vacant"}
+                      style={{ minWidth: 110 }}
+                    >
+                      {occupiedToggle ? "Occupied" : "Vacant"}
+                    </button>
+                  </div>
                 </div>
 
                 {/* Bottom row: Cancel & Save */}

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -428,13 +428,12 @@ export const TablesPage = () => {
                         idx = updated.findIndex((cell) => cell === null);
                       }
                       if (idx !== -1) {
-                        const nextTableNo =
-                          Math.max(
-                            0,
-                            ...grid
-                              .filter((t) => t !== null)
-                              .map((t) => t!.tableNo),
-                          ) + 1;
+                        // Find the smallest available table number
+                        const usedTableNos = grid.filter((t) => t !== null).map((t) => t!.tableNo);
+                        let nextTableNo = 1;
+                        while (usedTableNos.includes(nextTableNo)) {
+                          nextTableNo++;
+                        }
                         const newTable = {
                           tableNo: nextTableNo,
                           capacity: parseInt(capacityInput, 10),
@@ -925,6 +924,10 @@ export const TablesPage = () => {
                         (t) => t.tableNo === tableNo,
                       );
                       if (dbTable && dbTable._id) {
+                        // Clear order from kitchen management if table has an active order
+                        if (dbTable.activeOrderID) {
+                          await Meteor.callAsync("orders.removeOrder", dbTable.activeOrderID);
+                        }
                         await Meteor.callAsync(
                           "tables.removeTable",
                           dbTable._id,

--- a/imports/ui/pages/receipt/Receipt.tsx
+++ b/imports/ui/pages/receipt/Receipt.tsx
@@ -72,7 +72,11 @@ export const ReceiptPage = () => {
           <h2 className="text-center text-xl font-bold mb-4">Cafe</h2>
           <div className="flex justify-between mb-2">
             <p>Order No: {order.orderNo}</p>
-            <p>Table No: {order.tableNo}</p>
+            <p>
+              {order.tableNo != null
+                ? `Table No: ${order.tableNo}`
+                : "Takeaway"}
+            </p>
           </div>
           <p className="mb-2">Date: {new Date().toLocaleString()}</p>
 


### PR DESCRIPTION
Features:
- Refactored table and order schema: tables now track multiple orders via orderIDs and a single activeOrderID for the - current order.
- Ensured only the active order is displayed in POS and related components.
- "Add Order" button is not displayed for tables with an active order.
- Updated "Occupied"/"Vacant" toggles to be with consistent UI and logic.
- Added "Move Order" feature: allows moving an order to any unoccupied table, updates all relevant states and DB fields, and re-renders UI.
- Table numbers and order numbers now assigned sequentially, filling gaps for tables and starting orders from 1001.
- When marking a table vacant or deleting a table, the active order is cleared and removed from kitchen management.
- "Reopen" buttons in order history are disabled for paid orders.

Screenshots:

<img width="326" height="261" alt="image" src="https://github.com/user-attachments/assets/43113bb7-c38a-47b3-a290-ad43a8e6f5f8" />

Figure 1. Unoccupied table edit view.

<img width="321" height="401" alt="image" src="https://github.com/user-attachments/assets/5df92ca7-87d4-4555-ba6c-e0fee4991657" />

Figure 2. Occupied table edit view.

<img width="319" height="399" alt="image" src="https://github.com/user-attachments/assets/01d596f7-28fd-4c23-bffc-1b351c77f7c8" />

Figure 3. Moving order to an unoccupied table.

<img width="980" height="276" alt="image" src="https://github.com/user-attachments/assets/2dd29e00-d4fb-448f-8184-cfd3f9b10189" />

Figure 5. "Reopen" buttons in order history are disabled for paid orders (Order 1003).