### PR TITLE
Fix/pay feature order status

### DIFF
--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -17,6 +17,10 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
       alert("Cannot pay for an order with no items.");
       return;
     }
+    if (order.orderStatus !== OrderStatus.Served) {
+      alert("Only SERVED orders can be paid. Please mark as served first.");
+      return;
+    }
     setIsOpen(true);
   };
   const closeModal = () => setIsOpen(false);
@@ -24,7 +28,7 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
   const navigate = useNavigate();
 
   // Update order status
-  const updateOrderStatus = () => {
+  const finalizePayment = () => {
     if (!order || !order._id) {
       return;
     }
@@ -45,7 +49,7 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
   };
 
   const handleConfirm = () => {
-    updateOrderStatus();
+    finalizePayment();
     closeModal();
     navigate(`/receipt?orderNo=${order.orderNo}`);
   };
@@ -55,7 +59,11 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
       <button
         onClick={openModal}
         className="w-full bg-press-up-positive-button hover:bg-press-up-hover text-white font-bold py-2 px-4 rounded-full"
-        disabled={Boolean(order?.isLocked)}
+        disabled={
+          Boolean(order?.isLocked) ||
+          order.orderStatus !== OrderStatus.Served ||
+          order.menuItems.length === 0
+        }
       >
         Pay
       </button>

--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -69,8 +69,12 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
         >
           {isServed ? (
             <>
-              <h2 className="text-xl text-gray-700 font-bold mb-4">Confirm Payment</h2>
-              <p className="mb-6 text-gray-700">Are you sure you want to proceed with the payment?</p>
+              <h2 className="text-xl text-gray-700 font-bold mb-4">
+                Confirm Payment
+              </h2>
+              <p className="mb-6 text-gray-700">
+                Are you sure you want to proceed with the payment?
+              </p>
               <div className="grid grid-cols-2 justify-items-center gap-2">
                 <button
                   onClick={closeModal}
@@ -88,7 +92,9 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
             </>
           ) : (
             <>
-              <h2 className="text-xl text-gray-700 font-bold mb-4">Order is not served</h2>
+              <h2 className="text-xl text-gray-700 font-bold mb-4">
+                Order is not served
+              </h2>
               <p className="mb-4 text-gray-700">
                 Only <b>SERVED</b> orders can be paid.
               </p>

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -311,7 +311,7 @@ export const PosSideMenu = ({
                   onActiveOrderChange?.(v);
                 }}
               >
-                <option value="">Select Takeaway Order</option>
+                <option value="">Select Order</option>
                 {activeTakeawayOrders.map((o) => (
                   <option key={o._id} value={o._id}>
                     Order #{o.orderNo}


### PR DESCRIPTION
<img width="1161" height="653" alt="image" src="https://github.com/user-attachments/assets/b0f55107-7cca-46e5-ade6-21cb6944be58" />

<img width="986" height="311" alt="image" src="https://github.com/user-attachments/assets/ffd0425c-726c-4b02-bf3b-44139a19bd2e" />

<img width="1153" height="638" alt="image" src="https://github.com/user-attachments/assets/fdfe495c-52e3-46c5-830c-ef6477378744" />

<img width="820" height="266" alt="image" src="https://github.com/user-attachments/assets/bbd7ef4d-c6e2-4663-a85a-1d61207fe925" />


I added an extra restriction so that only served orders can be paid.

The current payment system had an issue where any order status could be paid, which sometimes triggered incorrect payments for orders that had not yet been served.

To prevent this, I added a restriction that allows payment only when the order status is served. If it isn’t, a message will appear showing the order status, and the payment cannot proceed.

There is no bug, and everything works properly. This change simply adds an extra restriction in the code.