### PR TITLE
Display Past Purchase Orders Correctly

### DIFF
--- a/imports/api/purchaseOrders/mock.ts
+++ b/imports/api/purchaseOrders/mock.ts
@@ -1,32 +1,65 @@
 import { faker } from "@faker-js/faker";
-import { SuppliersCollection } from "../suppliers/SuppliersCollection";
-import { PurchaseOrdersCollection } from "./PurchaseOrdersCollection";
+import { StockItemsCollection } from "../stockItems/StockItemsCollection";
+import {
+  PurchaseOrdersCollection,
+  StockItemLine,
+} from "./PurchaseOrdersCollection";
+import { Supplier } from "../suppliers/SuppliersCollection";
 
 export const mockPurchaseOrders = async (count: number) => {
   if ((await PurchaseOrdersCollection.countDocuments()) > 0) {
     await PurchaseOrdersCollection.dropCollectionAsync();
   }
 
-  for (let i = 0; i < count; ++i) {
-    const randomSupplier = (
-      await SuppliersCollection.rawCollection()
-        .aggregate([{ $sample: { size: 1 } }, { $project: { _id: 1 } }])
-        .toArray()
-    )[0];
+  // Get all suppliers that have associated stock items
+  const validSuppliers = (await StockItemsCollection.rawCollection()
+    .aggregate([
+      { $match: { supplier: { $ne: null } } },
+      { $group: { _id: "$supplier" } },
+      { $project: { _id: 1 } },
+    ])
+    .toArray()) as Supplier[];
 
-    const randomSupplierId = faker.datatype.boolean(0.75)
-      ? randomSupplier
-        ? randomSupplier._id
-          ? randomSupplier._id
-          : null
-        : null
-      : null;
+  if (validSuppliers.length === 0) {
+    console.warn(
+      "No suppliers with stock items found. Cannot create any mock purchase orders.",
+    );
+    return;
+  }
+
+  for (let i = 0; i < count; ++i) {
+    const randomSupplier = faker.helpers.arrayElement(validSuppliers);
+
+    const supplierStockItems = await StockItemsCollection.find({
+      supplier: randomSupplier._id,
+    }).fetchAsync();
+
+    const numLines = faker.number.int({ min: 1, max: 3 });
+    const shuffledItems = faker.helpers.shuffle(supplierStockItems);
+    const selectedItems = shuffledItems.slice(
+      0,
+      Math.min(numLines, supplierStockItems.length),
+    );
+
+    const stockItemLines: StockItemLine[] = [];
+    for (const stockItem of selectedItems) {
+      stockItemLines.push({
+        stockItem: stockItem._id,
+        quantity: faker.number.int({ min: 1, max: 20 }),
+        cost: faker.number.float({ min: 5, max: 100, fractionDigits: 2 }),
+      });
+    }
+
+    const calculatedTotalCost = stockItemLines.reduce(
+      (total, line) => total + line.cost * line.quantity,
+      0,
+    );
 
     await PurchaseOrdersCollection.insertAsync({
-      supplier: randomSupplierId,
+      supplier: randomSupplier._id,
       number: faker.number.int({ min: 1, max: 15 }),
-      stockItems: [],
-      totalCost: faker.number.int({ min: 1, max: 300 }),
+      stockItems: stockItemLines,
+      totalCost: calculatedTotalCost,
       date: new Date(),
     });
   }

--- a/imports/api/suppliers/SuppliersCollection.ts
+++ b/imports/api/suppliers/SuppliersCollection.ts
@@ -1,14 +1,15 @@
 import { Mongo } from "meteor/mongo";
-import { DBEntry } from "../database";
+import { DBEntry, OmitDB } from "../database";
 
 export interface Supplier extends DBEntry {
   name: string;
-  description: string;
-  pastOrderQty: number;
   phone?: string;
   email?: string;
   website?: string;
   address?: string;
 }
 
-export const SuppliersCollection = new Mongo.Collection<Supplier>("suppliers");
+export const SuppliersCollection = new Mongo.Collection<
+  OmitDB<Supplier>,
+  Supplier
+>("suppliers");

--- a/imports/api/suppliers/mock.ts
+++ b/imports/api/suppliers/mock.ts
@@ -9,8 +9,6 @@ export const mockSuppliers = async (count: number) => {
   for (let i = 0; i < count; ++i) {
     await SuppliersCollection.insertAsync({
       name: faker.company.name(),
-      description: faker.lorem.paragraph(),
-      pastOrderQty: faker.number.int({ min: 5, max: 100 }),
       phone: faker.phone.number(),
       email: faker.internet.email(),
       address: faker.location.streetAddress(),

--- a/imports/api/suppliers/supplierMethods.ts
+++ b/imports/api/suppliers/supplierMethods.ts
@@ -9,8 +9,6 @@ Meteor.methods({
     supplier: OmitDB<Supplier>,
   ) {
     check(supplier.name, String);
-    //check(supplier.description, String);
-    //check(supplier.pastOrderQty, Number);
     check(supplier.phone, String);
     check(supplier.email, String);
     check(supplier.website, String);
@@ -22,9 +20,7 @@ Meteor.methods({
   "suppliers.getNameById": async function (supplierId: string) {
     check(supplierId, String);
 
-    const supplier = await SuppliersCollection.findOneAsync({
-      _id: supplierId,
-    });
+    const supplier = await SuppliersCollection.findOneAsync(supplierId);
     return supplier?.name || "Unknown Supplier";
   },
 });

--- a/imports/ui/components/AddItemForm.tsx
+++ b/imports/ui/components/AddItemForm.tsx
@@ -1,5 +1,5 @@
 import { Meteor } from "meteor/meteor";
-import { useFind, useSubscribe } from "meteor/react-meteor-data";
+import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 import { FormEvent, useEffect, useState } from "react";
 import { SuppliersCollection, StockItem } from "/imports/api";
 import { IdType } from "/imports/api/database";
@@ -12,7 +12,10 @@ interface Props {
 
 export const AddItemForm = ({ onSuccess, item }: Props) => {
   useSubscribe("suppliers");
-  const suppliers = useFind(() => SuppliersCollection.find());
+  const suppliers = useTracker(
+    () => SuppliersCollection.find({}, { sort: { name: 1 } }).fetch(),
+    [],
+  );
 
   const [itemName, setItemName] = useState(item?.name ?? "");
   const [quantity, setQuantity] = useState<string>(

--- a/imports/ui/components/AddSupplierForm.tsx
+++ b/imports/ui/components/AddSupplierForm.tsx
@@ -17,11 +17,8 @@ export const AddSupplierForm = ({ onSuccess }: { onSuccess: () => void }) => {
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
 
-    //const parsedQuantity = parseInt(quantity, 10);
     if (
       !supplierName ||
-      //!description ||
-      //!pastOrderQty ||
       !email ||
       !validateEmail(email) ||
       !phone ||

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -1,18 +1,11 @@
 import React, { useState } from "react";
 import { Supplier } from "/imports/api/suppliers/SuppliersCollection";
 import { StockItemsCollection } from "/imports/api/stockItems/StockItemsCollection";
-import { useTracker } from "meteor/react-meteor-data";
+import { PurchaseOrdersCollection } from "/imports/api/purchaseOrders/PurchaseOrdersCollection";
+import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 import { Meteor } from "meteor/meteor";
 import { IdType } from "/imports/api/database";
 import { Cross } from "./symbols/GeneralSymbols";
-
-interface Order {
-  no: number;
-  date: string;
-  goods: string;
-  quantity: number;
-  totalCost: number;
-}
 
 interface SupplierInfoProps {
   supplier: Supplier;
@@ -30,6 +23,40 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
       { sort: { name: 1 } },
     ).fetch();
   }, [supplier._id]);
+
+  const isLoadingPurchaseOrders = useSubscribe("purchaseOrders");
+
+  const purchaseOrders = useTracker(() => {
+    if (isLoadingPurchaseOrders()) {
+      return [];
+    }
+
+    const purchaseOrders = PurchaseOrdersCollection.find(
+      { supplier: supplier._id },
+      { sort: { date: -1 } },
+    ).fetch();
+
+    const stockItemsMap = new Map(
+      StockItemsCollection.find()
+        .fetch()
+        .map((item) => [item._id, item.name]),
+    );
+
+    return purchaseOrders.flatMap((purchaseOrder) => {
+      return purchaseOrder.stockItems.map((stockItemLine) => {
+        const stockItemName =
+          stockItemsMap.get(stockItemLine.stockItem) || "Unknown Item";
+
+        return {
+          number: purchaseOrder.number,
+          date: purchaseOrder.date,
+          stockItemName: stockItemName,
+          quantity: stockItemLine.quantity,
+          totalCost: stockItemLine.cost * stockItemLine.quantity,
+        };
+      });
+    });
+  }, [supplier._id, isLoadingPurchaseOrders]);
 
   const removeItemFromSupplier = (itemId: IdType) => {
     if (
@@ -57,37 +84,11 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
   if (!supplier.address) supplier.address = "";
   if (!supplier.website) supplier.website = "";
 
-  // Note: Mock data for orders for Sprint 3 UI ONLY.
-  // In sem 2, connect Data from Database, OrdersCollection..
-  const orderHistory: Order[] = [
-    {
-      no: 135,
-      date: "06/04/2025",
-      goods: "Coffee Beans- 1KG",
-      quantity: 20,
-      totalCost: 300.0,
-    },
-    {
-      no: 134,
-      date: "06/03/2025",
-      goods: "Coffee Beans- 1KG",
-      quantity: 20,
-      totalCost: 300.0,
-    },
-    {
-      no: 133,
-      date: "06/02/2025",
-      goods: "Coffee Beans- 1KG",
-      quantity: 20,
-      totalCost: 300.0,
-    },
-  ];
-
-  const sortedOrders = [...orderHistory].sort((a, b) => {
-    const dateA = new Date(a.date).getTime();
-    const dateB = new Date(b.date).getTime();
-    return sortBy === "date-desc" ? dateB - dateA : dateA - dateB;
-  });
+  const sortedOrders = [...purchaseOrders].sort((a, b) =>
+    sortBy === "date-desc"
+      ? b.date.getTime() - a.date.getTime()
+      : a.date.getTime() - b.date.getTime(),
+  );
 
   if (!isExpanded) return null;
 
@@ -230,27 +231,42 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
                 </tr>
               </thead>
               <tbody>
-                {sortedOrders.map((order, index) => (
-                  <tr key={index} className="border-b border-gray-100">
-                    <td className="p-2 text-gray-800">{order.no}</td>
-                    <td className="p-2 text-gray-800">{order.date}</td>
-                    <td className="p-2 text-gray-800">{order.goods}</td>
-                    <td className="p-2 text-gray-800">{order.quantity}</td>
-                    <td className="p-2 text-gray-800">
-                      ${order.totalCost.toFixed(2)}
-                    </td>
-                    <td className="p-2">
-                      <button
-                        className="text-white text-xs px-3 py-1 rounded transition-colors"
-                        style={{
-                          backgroundColor: "#6f597b",
-                        }}
-                      >
-                        Repurchase
-                      </button>
+                {sortedOrders.length > 0 ? (
+                  sortedOrders.map((order, index) => (
+                    <tr key={index} className="border-b border-gray-100">
+                      <td className="p-2 text-gray-800">{order.number}</td>
+                      <td className="p-2 text-gray-800">
+                        {order.date.toLocaleDateString()}
+                      </td>
+                      <td className="p-2 text-gray-800">
+                        {order.stockItemName}
+                      </td>
+                      <td className="p-2 text-gray-800">{order.quantity}</td>
+                      <td className="p-2 text-gray-800">
+                        ${order.totalCost.toFixed(2)}
+                      </td>
+                      <td className="p-2">
+                        <button
+                          className="text-white text-xs px-3 py-1 rounded transition-colors"
+                          style={{
+                            backgroundColor: "#6f597b",
+                          }}
+                        >
+                          Repurchase
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td
+                      colSpan={6}
+                      className="p-4 text-center text-gray-500 italic"
+                    >
+                      No purchase orders found for this supplier
                     </td>
                   </tr>
-                ))}
+                )}
               </tbody>
             </table>
           </div>

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -24,12 +24,8 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
     ).fetch();
   }, [supplier._id]);
 
-  const isLoadingPurchaseOrders = useSubscribe("purchaseOrders");
+  useSubscribe("purchaseOrders");
   const purchaseOrders = useTracker(() => {
-    if (isLoadingPurchaseOrders()) {
-      return [];
-    }
-
     const purchaseOrders = PurchaseOrdersCollection.find(
       { supplier: supplier._id },
       { sort: { date: -1 } },
@@ -55,7 +51,7 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
         };
       });
     });
-  }, [supplier._id, isLoadingPurchaseOrders]);
+  }, [supplier._id]);
 
   const removeItemFromSupplier = (itemId: IdType) => {
     if (

--- a/imports/ui/components/SupplierInfo.tsx
+++ b/imports/ui/components/SupplierInfo.tsx
@@ -25,7 +25,6 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
   }, [supplier._id]);
 
   const isLoadingPurchaseOrders = useSubscribe("purchaseOrders");
-
   const purchaseOrders = useTracker(() => {
     if (isLoadingPurchaseOrders()) {
       return [];
@@ -213,7 +212,7 @@ export const SupplierInfo = ({ supplier, isExpanded }: SupplierInfoProps) => {
                     className="text-left p-2 font-medium text-white"
                     style={{ backgroundColor: "#6f597b" }}
                   >
-                    Goods
+                    Stock Item
                   </th>
                   <th
                     className="text-left p-2 font-medium text-white"

--- a/imports/ui/components/SupplierTable.tsx
+++ b/imports/ui/components/SupplierTable.tsx
@@ -26,14 +26,9 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
     return StockItemsCollection.find({}, { sort: { name: 1 } }).fetch();
   }, []);
 
-  const isLoadingPurchaseOrders = useSubscribe("purchaseOrders");
-
   // Calculate purchase order counts for each supplier
+  useSubscribe("purchaseOrders");
   const purchaseOrderCounts = useTracker(() => {
-    if (isLoadingPurchaseOrders()) {
-      return new Map();
-    }
-
     const counts = new Map();
     suppliers.forEach((supplier) => {
       const count = PurchaseOrdersCollection.find({
@@ -42,7 +37,7 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
       counts.set(supplier._id, count);
     });
     return counts;
-  }, [suppliers, isLoadingPurchaseOrders]);
+  }, [suppliers]);
 
   const toggleExpanded = (supplierId: string) => {
     setExpandedSupplierId(

--- a/imports/ui/components/SupplierTable.tsx
+++ b/imports/ui/components/SupplierTable.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { Supplier } from "/imports/api/suppliers/SuppliersCollection";
 import { StockItemsCollection } from "/imports/api/stockItems/StockItemsCollection";
+import { PurchaseOrdersCollection } from "/imports/api/purchaseOrders/PurchaseOrdersCollection";
 import { InfoSymbol, Cross } from "./symbols/GeneralSymbols";
 import { SupplierInfo } from "./SupplierInfo";
 import { Modal } from "./Modal";
 import { PurchaseOrderForm } from "./PurchaseOrderForm";
 import { Meteor } from "meteor/meteor";
 import { IdType } from "/imports/api/database";
-import { useTracker } from "meteor/react-meteor-data";
+import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 
 interface SupplierTableProps {
   suppliers: Supplier[];
@@ -24,6 +25,24 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
   const stockItems = useTracker(() => {
     return StockItemsCollection.find({}, { sort: { name: 1 } }).fetch();
   }, []);
+
+  const isLoadingPurchaseOrders = useSubscribe("purchaseOrders");
+
+  // Calculate purchase order counts for each supplier
+  const purchaseOrderCounts = useTracker(() => {
+    if (isLoadingPurchaseOrders()) {
+      return new Map();
+    }
+
+    const counts = new Map();
+    suppliers.forEach((supplier) => {
+      const count = PurchaseOrdersCollection.find({
+        supplier: supplier._id,
+      }).count();
+      counts.set(supplier._id, count);
+    });
+    return counts;
+  }, [suppliers, isLoadingPurchaseOrders]);
 
   const toggleExpanded = (supplierId: string) => {
     setExpandedSupplierId(
@@ -148,7 +167,7 @@ export const SupplierTable = ({ suppliers }: SupplierTableProps) => {
                 <div className="absolute bg-amber-700/25 w-px h-3/4 end-0 bottom-8" />
               </div>
               <div className="col-span-2 relative py-1 px-2 flex items-center justify-center">
-                {supplier.pastOrderQty}
+                {purchaseOrderCounts.get(supplier._id) || 0}
                 <div className="absolute bg-amber-700/25 w-px h-3/4 end-0 bottom-1/8" />
               </div>
               <div className="col-span-2 truncate py-1 px-2 flex items-center justify-center">

--- a/imports/ui/pages/debug/Debug.tsx
+++ b/imports/ui/pages/debug/Debug.tsx
@@ -30,9 +30,9 @@ export const DebugPage = () => {
   }
 
   const handleMethodCall = (methodName: string, successMessage: string) => {
-    Meteor.call(methodName, (error: any) => {
+    Meteor.call(methodName, (error: Meteor.Error) => {
       if (error) {
-        alert(`Failed: ${error.reason || error.message || "Unknown error"}`);
+        alert(`Failed: ${error.reason || "Unknown error"}`);
       } else {
         alert(`Success: ${successMessage}`);
       }

--- a/imports/ui/pages/inventory/Stock.tsx
+++ b/imports/ui/pages/inventory/Stock.tsx
@@ -40,9 +40,7 @@ export const StockPage = () => {
     for (const stockItem of stockItems) {
       let supplier: Supplier | null = null;
       if (stockItem.supplier != null) {
-        supplier = SuppliersCollection.find({
-          _id: stockItem.supplier,
-        }).fetch()[0];
+        supplier = SuppliersCollection.findOne(stockItem.supplier) || null;
       }
       result.push({ ...stockItem, supplier });
     }


### PR DESCRIPTION
Previously the Supplier Info screen only displayed mock purchase orders, implemented a fix that displays this correctly. Also correctly displays the counts for the past purchase orders in the suppliers table.

<img width="1299" height="711" alt="image" src="https://github.com/user-attachments/assets/cfa2670e-9842-40df-a6ec-6327302475ca" />
