### PR TITLE
Decouple Orders and Tables objects

### DIFF
--- a/imports/api/orders/OrdersCollection.ts
+++ b/imports/api/orders/OrdersCollection.ts
@@ -2,8 +2,6 @@ import { Mongo } from "meteor/mongo";
 import { DBEntry, OmitDB, IdType } from "../database";
 import { MenuItem } from "../menuItems/MenuItemsCollection";
 
-export type OrderType = "dine-in" | "takeaway";
-
 // OrderMenuItem reuses MenuItem shape but _id may be optional when created client-side
 export type OrderMenuItem = Omit<MenuItem, "_id"> & {
   _id?: IdType;
@@ -31,6 +29,11 @@ export enum OrderStatus {
   Preparing = "preparing",
   Ready = "ready",
   Served = "served",
+}
+
+export enum OrderType {
+  DineIn = "dine-in",
+  Takeaway = "takeaway",
 }
 
 export const OrdersCollection = new Mongo.Collection<OmitDB<Order>, Order>(

--- a/imports/api/orders/mock.ts
+++ b/imports/api/orders/mock.ts
@@ -5,6 +5,7 @@ import {
   OrderMenuItem,
   OrdersCollection,
   OrderStatus,
+  OrderType,
 } from "./OrdersCollection";
 
 export const mockOrders = async (count: number) => {
@@ -62,7 +63,7 @@ export const mockOrders = async (count: number) => {
 
     const orderID = await OrdersCollection.insertAsync({
       orderNo: nextOrderNo,
-      orderType: "dine-in",
+      orderType: OrderType.DineIn,
       tableNo,
       menuItems: items,
       totalPrice: total,
@@ -91,7 +92,7 @@ export const mockOrders = async (count: number) => {
 
     await OrdersCollection.insertAsync({
       orderNo: nextOrderNo,
-      orderType: "takeaway",
+      orderType: OrderType.Takeaway,
       tableNo: null,
       menuItems: items,
       totalPrice: total,

--- a/imports/api/orders/ordersMethods.ts
+++ b/imports/api/orders/ordersMethods.ts
@@ -46,7 +46,7 @@ Meteor.methods({
         {},
         { sort: { orderNo: -1 }, limit: 1 },
       ).fetchAsync();
-      let nextOrderNo = 1;
+      let nextOrderNo = 1001;
       if (lastOrder.length > 0 && typeof lastOrder[0].orderNo === "number") {
         nextOrderNo = lastOrder[0].orderNo + 1;
       }

--- a/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
@@ -1,10 +1,12 @@
 import { IdType } from "/imports/api/database";
+import { OrderType } from "/imports/api/orders/OrdersCollection";
 
 export type OrderStatus = "pending" | "preparing" | "ready" | "served";
 
 export type UiOrder = {
   _id: IdType;
   orderNo: number;
+  orderType: OrderType;
   status: OrderStatus;
   tableNo: number | null;
   createdAt: string;

--- a/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/OrderCard.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 import type { UiOrder } from "./KitchenMgmtTypes";
+import { OrderType } from "/imports/api/orders/OrdersCollection";
 
 type UiMenuItem = UiOrder["menuItems"][number];
 
@@ -199,8 +200,10 @@ export const OrderCard = ({ order }: OrderCardProps) => {
 
           <div>
             <p className="font-bold text-lg text-press-up-purple">
-              {order.tableNo != null
-                ? `Table No: ${order.tableNo}`
+              {order.orderType == OrderType.DineIn
+                ? order.tableNo == null
+                  ? "Dine-In"
+                  : `Table No: ${order.tableNo}`
                 : "Takeaway"}
             </p>
             <p className="text-sm text-press-up-purple">{order.createdAt}</p>
@@ -237,8 +240,10 @@ export const OrderCard = ({ order }: OrderCardProps) => {
           </p>
           <p>
             <strong>
-              {order.tableNo != null
-                ? `Table No: ${order.tableNo}`
+              {order.orderType == OrderType.DineIn
+                ? order.tableNo == null
+                  ? "Dine-In"
+                  : `Table No: ${order.tableNo}`
                 : "Takeaway"}
             </strong>
           </p>

--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -43,7 +43,10 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
   const handleConfirm = () => {
     finalizePayment();
     closeModal();
-    navigate(`/receipt?orderNo=${order.orderNo}`);
+    if (order._id) {
+      sessionStorage.setItem("activeOrderId", order._id);
+    }
+    navigate("/receipt");
   };
 
   return (

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { Meteor } from "meteor/meteor";
-import { MenuItem, Tables } from "/imports/api";
+import { MenuItem } from "/imports/api";
 import { OrderMenuItem } from "/imports/api/orders/OrdersCollection";
 import { PaymentModal } from "./PaymentModal";
 import { useSubscribe, useTracker } from "meteor/react-meteor-data";
-import { Order, OrdersCollection, TablesCollection } from "/imports/api";
+import { Order, OrdersCollection } from "/imports/api";
 import { IdType } from "/imports/api/database";
 import { Roles } from "meteor/alanning:roles";
 import { RoleEnum } from "/imports/api/accounts/roles";
 import { Hide } from "./display/Hide";
-import { useNavigate, useLocation } from "react-router";
 import { Button } from "./interaction/Button";
 
 interface PosSideMenuProps {
@@ -21,8 +20,6 @@ interface PosSideMenuProps {
   onDecrease: (itemId: IdType) => void;
   onDelete: (itemId: IdType) => void;
   onUpdateOrder?: (fields: Partial<Order>) => void;
-  selectedTable: number | null;
-  setSelectedTable: (tableNo: number) => void;
   onActiveOrderChange?: (orderId: string | null) => void;
 }
 
@@ -34,17 +31,22 @@ export const PosSideMenu = ({
   onDecrease,
   onDelete,
   onUpdateOrder,
-  selectedTable,
-  setSelectedTable,
   onActiveOrderChange,
 }: PosSideMenuProps) => {
   // Fetch the current order for this table
   useSubscribe("orders");
   useSubscribe("tables");
   const [orderType, setOrderType] = useState<"dine-in" | "takeaway">("dine-in");
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
 
-  const [selectedTakeawayId, setSelectedTakeawayId] = useState<string | null>(
-    null,
+  // List active orders for each type
+  const activeDineInOrders = useTracker(
+    () =>
+      OrdersCollection.find(
+        { orderType: "dine-in", paid: false },
+        { sort: { orderNo: 1 } },
+      ).fetch(),
+    [],
   );
   const activeTakeawayOrders = useTracker(
     () =>
@@ -55,20 +57,13 @@ export const PosSideMenu = ({
     [],
   );
 
+  // Select order by id
   const order = useTracker(() => {
-    if (orderType === "dine-in" && selectedTable != null) {
-      // Find the table and get its activeOrderID
-      const table = TablesCollection.findOne({ tableNo: selectedTable });
-      if (table?.activeOrderID) {
-        return OrdersCollection.findOne(table.activeOrderID) ?? null;
-      }
-      return null;
-    }
-    if (orderType === "takeaway" && selectedTakeawayId) {
-      return OrdersCollection.findOne(selectedTakeawayId as string) ?? null;
+    if (selectedOrderId) {
+      return OrdersCollection.findOne(selectedOrderId as string) ?? null;
     }
     return null;
-  }, [orderType, selectedTable, selectedTakeawayId]);
+  }, [selectedOrderId]);
 
   const displayedItems = order?.menuItems ?? [];
   const baseTotal =
@@ -229,24 +224,6 @@ export const PosSideMenu = ({
     }
   };
 
-  const tables: Tables[] = useTracker(
-    () => TablesCollection.find({}, { sort: { tableNo: 1 } }).fetch(),
-    [],
-  );
-
-  const navigate = useNavigate();
-  const location = useLocation();
-
-  // Table change handler
-  const handleTableChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selected = Number(e.target.value);
-    setSelectedTable(selected);
-    // Update the URL with the new tableNo as a query parameter
-    const params = new URLSearchParams(location.search);
-    params.set("tableNo", String(selected));
-    navigate(`${location.pathname}?${params.toString()}`);
-  };
-
   const rolesLoaded = useSubscribe("users.roles")();
   const rolesGraphLoaded = useSubscribe("users.rolesGraph")();
   const canLockOrder = useTracker(
@@ -282,72 +259,53 @@ export const PosSideMenu = ({
           </button>
         </div>
 
-        {/* Table Dropdown or Takeaway */}
+        {/* Order Dropdown for Dine-in and Takeaway */}
         <div className="flex justify-center items-center relative">
-          {orderType === "dine-in" ? (
-            <select
-              className="text-lg font-semibold bg-press-up-purple text-white border-none outline-none"
-              value={selectedTable ?? ""}
-              onChange={handleTableChange}
+          <div className="absolute left-0">
+            <button
+              className="px-3 rounded-full font-semibold text-m transition-colors duration-200 bg-white text-press-up-purple hover:bg-gray-300"
+              onClick={async () => {
+                try {
+                  // create a fresh order for current type
+                  const newId = await Meteor.callAsync("orders.addOrder", {
+                    orderType,
+                    tableNo: null,
+                    menuItems: [],
+                    totalPrice: 0,
+                    createdAt: new Date(),
+                    orderStatus: "pending",
+                    paid: false,
+                  });
+                  setSelectedOrderId(String(newId));
+                  onActiveOrderChange?.(String(newId));
+                } catch (e) {
+                  console.error(e);
+                  alert("Failed to create order.");
+                }
+              }}
             >
-              {tables.map((table) => (
-                <option
-                  key={table.tableNo}
-                  value={table.tableNo}
-                  disabled={!table.isOccupied}
-                  className={table.isOccupied ? "bg-red-400" : "bg-green-400"}
-                >
-                  Table {table.tableNo}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <div className="flex items-center gap-2">
-              <div className="absolute left-0">
-                <button
-                  className="px-3 rounded-full font-semibold text-m transition-colors duration-200 bg-white text-press-up-purple hover:bg-gray-300"
-                  onClick={async () => {
-                    try {
-                      // create a fresh takeaway order
-                      const newId = await Meteor.callAsync("orders.addOrder", {
-                        orderType: "takeaway",
-                        tableNo: null,
-                        menuItems: [],
-                        totalPrice: 0,
-                        createdAt: new Date(),
-                        orderStatus: "pending",
-                        paid: false,
-                      });
-                      setSelectedTakeawayId(String(newId)); // select the new order immediately
-                      onActiveOrderChange?.(String(newId));
-                    } catch (e) {
-                      console.error(e);
-                      alert("Failed to create takeaway order.");
-                    }
-                  }}
-                >
-                  +
-                </button>
-              </div>
-              <select
-                className="text-lg font-semibold bg-press-up-purple text-white border-none outline-none"
-                value={selectedTakeawayId ?? ""}
-                onChange={(e) => {
-                  const v = e.target.value || null;
-                  setSelectedTakeawayId(v);
-                  onActiveOrderChange?.(v);
-                }}
-              >
-                <option value="">Select Order</option>
-                {activeTakeawayOrders.map((o) => (
-                  <option key={o._id} value={o._id}>
-                    Order #{o.orderNo}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
+              +
+            </button>
+          </div>
+          <select
+            className="text-lg font-semibold bg-press-up-purple text-white border-none outline-none"
+            value={selectedOrderId ?? ""}
+            onChange={(e) => {
+              const v = e.target.value || null;
+              setSelectedOrderId(v);
+              onActiveOrderChange?.(v);
+            }}
+          >
+            <option value="">Select Order</option>
+            {(orderType === "dine-in"
+              ? activeDineInOrders
+              : activeTakeawayOrders
+            ).map((o) => (
+              <option key={o._id} value={o._id}>
+                Order #{o.orderNo}
+              </option>
+            ))}
+          </select>
           {/* Lock button (managers only) */}
           <Hide hide={!canLockOrder}>
             <button
@@ -420,78 +378,19 @@ export const PosSideMenu = ({
             })
           ) : (
             <div className="p-4 text-center text-gray-500">
-              {selectedTable != null &&
-              tables.find((t) => t.tableNo === selectedTable)?.isOccupied &&
-              !tables.find((t) => t.tableNo === selectedTable)
-                ?.activeOrderID ? (
-                /* dine-in empty: show "start new order for table" card (keep as-is) */
+              {/* Empty state for no order selected */}
+              {!selectedOrderId && (
                 <div className="bg-yellow-100 p-4 rounded-md space-y-2">
                   <p className="font-bold text-gray-800 mb-2">
-                    No active orders for this table.
-                  </p>
-                  <Button
-                    variant="positive"
-                    width="full"
-                    onClick={async () => {
-                      try {
-                        console.log("Creating order for table:", selectedTable);
-                        const dbTable = tables.find(
-                          (t) => t.tableNo === selectedTable,
-                        );
-                        if (!dbTable || !dbTable._id) {
-                          alert("Could not find table in database.");
-                          return;
-                        }
-
-                        const orderId = await Meteor.callAsync(
-                          "orders.addOrder",
-                          {
-                            tableNo: selectedTable,
-                            menuItems: [],
-                            totalPrice: 0,
-                            createdAt: new Date(),
-                            orderStatus: "pending",
-                            paid: false,
-                          },
-                        );
-
-                        await Meteor.callAsync(
-                          "tables.addOrder",
-                          dbTable._id,
-                          orderId,
-                        );
-
-                        console.log("Order created:", orderId);
-                      } catch (err) {
-                        console.error("Error adding order:", err);
-                        alert(
-                          "Failed to add order. Check console for details.",
-                        );
-                      }
-                    }}
-                    disabled={
-                      !!tables.find(
-                        (t) => t.tableNo === selectedTable && t.activeOrderID, // <-- Only block if there's an active order
-                      )
-                    }
-                  >
-                    Start a new order?
-                  </Button>
-                </div>
-              ) : orderType === "takeaway" && !selectedTakeawayId ? (
-                /* takeaway empty + no selected order: show helper */
-                <div className="bg-yellow-100 p-4 rounded-md space-y-2">
-                  <p className="font-bold text-gray-800 mb-2">
-                    No active takeaway order.
+                    No active {orderType} order.
                   </p>
                   <p className="text-sm text-gray-700">
                     Use the + button above to create a new order.
                   </p>
                 </div>
-              ) : (
-                /* takeaway with an order selected but no items: show nothing (so the user can add from menu) */
-                <span className="sr-only">{/* keep area clean */}</span>
               )}
+              {/* If order selected but no items, show nothing (allow adding from menu) */}
+              {selectedOrderId && <span className="sr-only" />}
             </div>
           )}
         </div>

--- a/imports/ui/components/PosSideMenu.tsx
+++ b/imports/ui/components/PosSideMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Meteor } from "meteor/meteor";
 import { MenuItem } from "/imports/api";
-import { OrderMenuItem } from "/imports/api/orders/OrdersCollection";
+import { OrderMenuItem, OrderType } from "/imports/api/orders/OrdersCollection";
 import { PaymentModal } from "./PaymentModal";
 import { useSubscribe, useTracker } from "meteor/react-meteor-data";
 import { Order, OrdersCollection } from "/imports/api";
@@ -36,7 +36,9 @@ export const PosSideMenu = ({
   // Fetch the current order for this table
   useSubscribe("orders");
   useSubscribe("tables");
-  const [orderType, setOrderType] = useState<"dine-in" | "takeaway">("dine-in");
+  const [orderType, setOrderType] = useState<
+    OrderType.DineIn | OrderType.Takeaway
+  >(OrderType.DineIn);
 
   // Use sessionStorage for activeOrderId
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(() => {
@@ -47,7 +49,7 @@ export const PosSideMenu = ({
   const activeDineInOrders = useTracker(
     () =>
       OrdersCollection.find(
-        { orderType: "dine-in", paid: false },
+        { orderType: OrderType.DineIn, paid: false },
         { sort: { orderNo: 1 } },
       ).fetch(),
     [],
@@ -55,7 +57,7 @@ export const PosSideMenu = ({
   const activeTakeawayOrders = useTracker(
     () =>
       OrdersCollection.find(
-        { orderType: "takeaway", paid: false },
+        { orderType: OrderType.Takeaway, paid: false },
         { sort: { createdAt: -1 } },
       ).fetch(),
     [],
@@ -147,11 +149,11 @@ export const PosSideMenu = ({
   };
 
   // Function to get lowest unpaid order depending on the order type
-  const getLowestOrderId = (type: "dine-in" | "takeaway") => {
+  const getLowestOrderId = (type: OrderType.DineIn | OrderType.Takeaway) => {
     const orders = OrdersCollection.find(
-      type === "dine-in"
-        ? { orderType: "dine-in", paid: false }
-        : { orderType: "takeaway", paid: false },
+      type === OrderType.DineIn
+        ? { orderType: OrderType.DineIn, paid: false }
+        : { orderType: OrderType.Takeaway, paid: false },
       type === "dine-in"
         ? { sort: { orderNo: 1 } }
         : { sort: { createdAt: -1 } },
@@ -272,8 +274,8 @@ export const PosSideMenu = ({
         <div className="flex justify-center gap-2 mb-2 relative">
           <button
             onClick={() => {
-              setOrderType("dine-in");
-              setActiveOrder(getLowestOrderId("dine-in"));
+              setOrderType(OrderType.DineIn);
+              setActiveOrder(getLowestOrderId(OrderType.DineIn));
             }}
             className={`px-3 py-1 rounded-full font-semibold ${
               orderType === "dine-in"
@@ -285,8 +287,8 @@ export const PosSideMenu = ({
           </button>
           <button
             onClick={() => {
-              setOrderType("takeaway");
-              setActiveOrder(getLowestOrderId("takeaway"));
+              setOrderType(OrderType.Takeaway);
+              setActiveOrder(getLowestOrderId(OrderType.Takeaway));
             }}
             className={`px-3 py-1 rounded-full font-semibold ${
               orderType === "takeaway"
@@ -341,7 +343,7 @@ export const PosSideMenu = ({
             }}
           >
             <option value="">Select Order</option>
-            {(orderType === "dine-in"
+            {(orderType === OrderType.DineIn
               ? activeDineInOrders
               : activeTakeawayOrders
             ).map((o) => (
@@ -703,7 +705,9 @@ export const PosSideMenu = ({
             <div className="my-4">
               <PaymentModal
                 tableNo={
-                  order.orderType === "dine-in" ? (order.tableNo ?? null) : null
+                  order.orderType === OrderType.DineIn
+                    ? (order.tableNo ?? null)
+                    : null
                 }
                 order={order}
               />

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -42,6 +42,7 @@ export const KitchenManagement = () => {
         _id: doc._id,
         orderNo: doc.orderNo,
         tableNo: doc.tableNo ?? null,
+        orderType: doc.orderType,
         createdAt: new Date(doc.createdAt).toLocaleTimeString().toUpperCase(),
         createdAtMs: created.getTime(),
         status: doc.orderStatus,

--- a/imports/ui/pages/pos/MainDisplay.tsx
+++ b/imports/ui/pages/pos/MainDisplay.tsx
@@ -47,7 +47,6 @@ export const MainDisplay = () => {
     return matchesName && matchesCategory && isAvailable;
   });
 
-
   // Update order status (accept partial updates)
   const updateOrderInDb = (updatedFields: Partial<Order>) => {
     if (!order || !order._id) return;

--- a/imports/ui/pages/pos/MainDisplay.tsx
+++ b/imports/ui/pages/pos/MainDisplay.tsx
@@ -1,5 +1,4 @@
 import { MenuItemsCollection, OrdersCollection } from "/imports/api";
-import { TablesCollection } from "/imports/api";
 import { PosItemCard } from "../../components/PosItemCard";
 import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 import { PosSideMenu } from "../../components/PosSideMenu";
@@ -13,7 +12,6 @@ import {
 } from "/imports/api/orders/OrdersCollection";
 import { MenuItem } from "/imports/api/menuItems/MenuItemsCollection";
 import { IdType } from "/imports/api/database";
-import { useLocation } from "react-router";
 
 export const MainDisplay = () => {
   const [_, setPageTitle] = usePageTitle();
@@ -23,28 +21,19 @@ export const MainDisplay = () => {
 
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [selectedTable, setSelectedTable] = useState<number | null>(null);
-  const location = useLocation();
   const [activeOrderId, setActiveOrderId] = useState<string | null>(null);
 
   useSubscribe("menuItems");
   useSubscribe("orders");
-  useSubscribe("tables");
 
-  const tables = useTracker(() => TablesCollection.find().fetch());
   const posItems = useTracker(() => MenuItemsCollection.find().fetch());
-  // Fetch the current order for the selected table
+  // Only use activeOrderId for order selection
   const order = useTracker(() => {
     if (activeOrderId) {
       return OrdersCollection.findOne(activeOrderId as string) ?? null;
     }
-    return selectedTable
-      ? (OrdersCollection.find({
-          tableNo: selectedTable,
-          $or: [{ orderType: "dine-in" }, { orderType: { $exists: false } }],
-        }).fetch()[0] ?? null)
-      : null;
-  }, [activeOrderId, selectedTable]);
+    return null;
+  }, [activeOrderId]);
 
   const filteredItems = posItems.filter((item) => {
     const matchesName = item.name
@@ -58,29 +47,6 @@ export const MainDisplay = () => {
     return matchesName && matchesCategory && isAvailable;
   });
 
-  useEffect(() => {
-    if (selectedTable !== null) return; // Only set on initial load
-
-    if (tables.length > 0) {
-      // Find the lowest table number that is occupied
-      const occupiedTables = tables.filter((t) => t.isOccupied);
-      if (occupiedTables.length > 0) {
-        const lowestOccupiedTableNo = Math.min(
-          ...occupiedTables.map((t) => t.tableNo),
-        );
-        setSelectedTable(lowestOccupiedTableNo);
-        return;
-      }
-    }
-  }, [tables, selectedTable]);
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const tableNoParam = params.get("tableNo");
-    if (tableNoParam) {
-      setSelectedTable(Number(tableNoParam));
-    }
-  }, [location.search]);
 
   // Update order status (accept partial updates)
   const updateOrderInDb = (updatedFields: Partial<Order>) => {
@@ -302,7 +268,7 @@ export const MainDisplay = () => {
       {/* Side Panel */}
       <div id="pos-side-panel" className="p-4">
         <PosSideMenu
-          tableNo={order?.tableNo || selectedTable}
+          tableNo={order?.tableNo ?? null}
           items={order?.menuItems || []}
           total={order?.totalPrice || 0}
           orderId={order?._id}
@@ -310,8 +276,6 @@ export const MainDisplay = () => {
           onDecrease={handleDecrease}
           onDelete={handleDelete}
           onUpdateOrder={updateOrderInDb}
-          selectedTable={selectedTable} // pass down
-          setSelectedTable={setSelectedTable} // pass down
           onActiveOrderChange={setActiveOrderId}
         />
       </div>

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -3,7 +3,10 @@ import React, { useEffect, useState } from "react";
 import { usePageTitle } from "../../hooks/PageTitleContext";
 import { useSubscribe, useTracker } from "meteor/react-meteor-data";
 import { TablesCollection } from "/imports/api/tables/TablesCollection";
-import { OrdersCollection } from "/imports/api/orders/OrdersCollection";
+import {
+  OrdersCollection,
+  OrderType,
+} from "/imports/api/orders/OrdersCollection";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { useNavigate } from "react-router";
@@ -623,7 +626,7 @@ export const TablesPage = () => {
                           .filter(
                             (o) =>
                               !o.paid &&
-                              o.orderType === "dine-in" &&
+                              o.orderType === OrderType.DineIn &&
                               o.tableNo === null,
                           )
                           .map((o) => (

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -300,7 +300,10 @@ export const TablesPage = () => {
     }
   };
 
-  const goToOrder = () => {
+  const goToOrder = (orderId?: string) => {
+    if (orderId) {
+      sessionStorage.setItem("activeOrderId", orderId);
+    }
     navigate("/pos/orders");
   };
 
@@ -590,7 +593,7 @@ export const TablesPage = () => {
                           setGrid(updated);
                           setModalType(null);
                           markChanged();
-                          goToOrder();
+                          goToOrder(String(orderId));
                         } catch (err) {
                           console.error("Error adding order:", err);
                           alert(

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -300,12 +300,8 @@ export const TablesPage = () => {
     }
   };
 
-  const goToOrder = (tableNo?: number) => {
-    if (tableNo !== null) {
-      navigate(`/pos/orders?tableNo=${tableNo}`);
-    } else {
-      navigate("/pos/orders");
-    }
+  const goToOrder = () => {
+    navigate("/pos/orders");
   };
 
   // initialize modal-local fields from snapshot when opening edit modal
@@ -594,7 +590,7 @@ export const TablesPage = () => {
                           setGrid(updated);
                           setModalType(null);
                           markChanged();
-                          goToOrder(editTableData!.tableNo);
+                          goToOrder();
                         } catch (err) {
                           console.error("Error adding order:", err);
                           alert(

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -672,6 +672,8 @@ export const TablesPage = () => {
                           });
                           setGrid(newGrid);
                           setModalType(null);
+                          markChanged();
+                          goToOrder(String(selectedMoveOrderNo));
                         }}
                       >
                         Add Order

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -542,7 +542,38 @@ export const TablesPage = () => {
                   </>
                 )}
                 {/* Top row: Occupied toggle */}
-                <div className="flex items-center gap-2 mb-3 justify-end">
+                <div
+                  className={`flex items-center gap-2 mb-3 ${
+                    tablesFromDb.find(
+                      (t) =>
+                        t.tableNo === editTableData!.tableNo && t.activeOrderID,
+                    )
+                      ? "justify-between"
+                      : "justify-end"
+                  }`}
+                >
+                  {/* Go to Order button (only displays for Table which has an active order) */}
+                  {(() => {
+                    const order = editTableData?.activeOrderID
+                      ? orders.find(
+                          (o) => o._id === editTableData.activeOrderID,
+                        )
+                      : null;
+                    if (!order) return null;
+                    return (
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            goToOrder(String(editTableData?.activeOrderID));
+                          }}
+                          variant="positive"
+                        >
+                          {`Go to Order #${order.orderNo}`}
+                        </Button>
+                      </div>
+                    );
+                  })()}
                   {/* Occupied/Vacant Toggle */}
                   <div className="flex gap-2">
                     <Button

--- a/imports/ui/pages/pos/Tables.tsx
+++ b/imports/ui/pages/pos/Tables.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { usePageTitle } from "../../hooks/PageTitleContext";
 import { useSubscribe, useTracker } from "meteor/react-meteor-data";
 import { TablesCollection } from "/imports/api/tables/TablesCollection";
+import { OrdersCollection } from "/imports/api/orders/OrdersCollection";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { useNavigate } from "react-router";
@@ -123,6 +124,12 @@ export const TablesPage = () => {
     TablesCollection.find({}, { sort: { tableNo: 1 } }).fetch(),
   );
 
+  // Non-assigned dine-in orders for dropdown
+  useSubscribe("orders");
+  const orders = useTracker(() =>
+    OrdersCollection.find({}, { sort: { orderNo: 1 } }).fetch(),
+  );
+
   const MAX_NO_TABLES = 20;
   const GRID_COLS = 5;
   const GRID_ROWS = Math.ceil(MAX_NO_TABLES / GRID_COLS);
@@ -159,7 +166,10 @@ export const TablesPage = () => {
   const [confirmAction, setConfirmAction] = useState<(() => void) | null>(null);
   const [clearOrderOnSave, setClearOrderOnSave] = useState(false);
   const [deleteTableInput, setDeleteTableInput] = useState("");
-  const [selectedMoveTableNo, setSelectedMoveTableNo] = useState<number | null>(
+  const [selectedMoveTableNo, setSelectedMoveTableNo] = useState<string | null>(
+    null,
+  );
+  const [selectedMoveOrderNo, setSelectedMoveOrderNo] = useState<string | null>(
     null,
   );
 
@@ -528,84 +538,8 @@ export const TablesPage = () => {
                     />
                   </>
                 )}
-                {/* Top row: Add Order + Occupied toggle */}
-                <div
-                  className={`flex items-center gap-2 mb-3 ${
-                    tablesFromDb.find(
-                      (t) =>
-                        t.tableNo === editTableData!.tableNo && t.activeOrderID,
-                    )
-                      ? "justify-end"
-                      : "justify-between"
-                  }`}
-                >
-                  {/* Add Order Button */}
-                  {!tablesFromDb.find(
-                    (t) =>
-                      t.tableNo === editTableData!.tableNo &&
-                      t.activeOrderID &&
-                      t.isOccupied,
-                  ) && (
-                    <Button
-                      variant="positive"
-                      onClick={async () => {
-                        try {
-                          const dbTable = tablesFromDb.find(
-                            (t) => t.tableNo === editTableData!.tableNo,
-                          );
-                          if (!dbTable || !dbTable._id) {
-                            alert("Could not find table in database.");
-                            return;
-                          }
-
-                          // Create new order (only if no existing one, because we disable otherwise)
-                          const orderId = await Meteor.callAsync(
-                            "orders.addOrder",
-                            {
-                              // orderNo is now auto-generated server-side
-                              tableNo: editTableData!.tableNo,
-                              orderType: "dine-in",
-                              menuItems: [],
-                              totalPrice: 0,
-                              createdAt: new Date(),
-                              orderStatus: "pending",
-                              paid: false,
-                            },
-                          );
-
-                          // Link order to table
-                          await Meteor.callAsync(
-                            "tables.addOrder",
-                            dbTable._id,
-                            orderId,
-                          );
-
-                          // Update local grid
-                          const updated = grid.map((t) =>
-                            t?.tableNo === editTableData!.tableNo
-                              ? {
-                                  ...t,
-                                  isOccupied: true,
-                                  activeOrderID: String(orderId),
-                                }
-                              : t,
-                          );
-                          setGrid(updated);
-                          setModalType(null);
-                          markChanged();
-                          goToOrder(String(orderId));
-                        } catch (err) {
-                          console.error("Error adding order:", err);
-                          alert(
-                            "Failed to add order. Check console for details.",
-                          );
-                        }
-                      }}
-                    >
-                      Add Order
-                    </Button>
-                  )}
-
+                {/* Top row: Occupied toggle */}
+                <div className="flex items-center gap-2 mb-3 justify-end">
                   {/* Occupied/Vacant Toggle */}
                   <div className="flex gap-2">
                     <Button
@@ -668,6 +602,84 @@ export const TablesPage = () => {
                   </div>
                 </div>
 
+                {/* Add Order to Table */}
+                {!editTableData?.activeOrderID && (
+                  <div className="mb-3">
+                    <hr></hr>
+                    <label className="block mt-2 font-semibold">
+                      Add Order to Table:
+                    </label>
+                    <div className="mb-3 flex flex-row items-center justify-between gap-2">
+                      <select
+                        value={selectedMoveOrderNo ?? ""}
+                        onChange={(e) => setSelectedMoveOrderNo(e.target.value)}
+                        className="text-lg font-semibold bg-press-up-negative-button text-white border-none outline-none rounded-full px-4 py-2 shadow-md"
+                        style={{ minWidth: 160 }}
+                      >
+                        <option value="" className="bg-white text-gray-700">
+                          Select Order
+                        </option>
+                        {orders
+                          .filter(
+                            (o) =>
+                              !o.paid &&
+                              o.orderType === "dine-in" &&
+                              o.tableNo === null,
+                          )
+                          .map((o) => (
+                            <option
+                              key={o._id}
+                              value={o._id}
+                              className="bg-white text-gray-700"
+                            >
+                              Order #{o.orderNo}
+                            </option>
+                          ))}
+                      </select>
+                      <Button
+                        variant="negative"
+                        disabled={!selectedMoveOrderNo}
+                        onClick={async () => {
+                          // Update the selected order's tableNo
+                          await Meteor.callAsync(
+                            "orders.updateOrder",
+                            selectedMoveOrderNo,
+                            { tableNo: editTableData.tableNo },
+                          );
+                          // Add order to table
+                          await Meteor.callAsync(
+                            "tables.addOrder",
+                            editTableData._id,
+                            selectedMoveOrderNo,
+                          );
+                          // Set table as occupied with at least 1 occupant
+                          await Meteor.callAsync(
+                            "tables.setOccupied",
+                            editTableData._id,
+                            true,
+                            1,
+                          );
+                          // Re-render by updating grid from DB
+                          const refreshedTables = TablesCollection.find(
+                            {},
+                            { sort: { tableNo: 1 } },
+                          ).fetch();
+                          const newGrid = Array(GRID_SIZE).fill(null);
+                          refreshedTables.forEach((table, idx) => {
+                            if (idx < GRID_SIZE) {
+                              newGrid[idx] = table;
+                            }
+                          });
+                          setGrid(newGrid);
+                          setModalType(null);
+                        }}
+                      >
+                        Add Order
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
                 {/* Move Order to Table */}
                 {editTableData?.activeOrderID && (
                   <div className="mb-3">
@@ -678,9 +690,7 @@ export const TablesPage = () => {
                     <div className="mb-3 flex flex-row items-center justify-between gap-2">
                       <select
                         value={selectedMoveTableNo ?? ""}
-                        onChange={(e) =>
-                          setSelectedMoveTableNo(Number(e.target.value))
-                        }
+                        onChange={(e) => setSelectedMoveTableNo(e.target.value)}
                         className="text-lg font-semibold bg-press-up-negative-button text-white border-none outline-none rounded-full px-4 py-2 shadow-md"
                         style={{ minWidth: 160 }}
                       >
@@ -708,7 +718,7 @@ export const TablesPage = () => {
                         disabled={!selectedMoveTableNo}
                         onClick={async () => {
                           const newTable = tablesFromDb.find(
-                            (t) => t.tableNo === selectedMoveTableNo,
+                            (t) => t.tableNo === Number(selectedMoveTableNo),
                           );
                           if (!newTable || !editTableData.activeOrderID) return;
                           // Clear old table

--- a/imports/ui/pages/receipt/Receipt.tsx
+++ b/imports/ui/pages/receipt/Receipt.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 import { useNavigate } from "react-router";
-import { OrdersCollection } from "/imports/api/orders/OrdersCollection";
+import {
+  OrdersCollection,
+  OrderType,
+} from "/imports/api/orders/OrdersCollection";
 
 export const ReceiptPage = () => {
   const navigate = useNavigate();
@@ -13,8 +16,8 @@ export const ReceiptPage = () => {
   // Find lowest unpaid dine-in order
   const lowestDineInOrderId = useTracker(() => {
     const orders = OrdersCollection.find(
-      { orderType: "dine-in", paid: false },
-      { sort: { orderNo: 1 } }
+      { orderType: OrderType.DineIn, paid: false },
+      { sort: { orderNo: 1 } },
     ).fetch();
     return orders.length > 0 ? orders[0]._id : null;
   }, []);
@@ -70,8 +73,10 @@ export const ReceiptPage = () => {
           <div className="flex justify-between mb-2">
             <p>Order No: {order.orderNo}</p>
             <p>
-              {order.tableNo != null
-                ? `Table No: ${order.tableNo}`
+              {order.orderType == OrderType.DineIn
+                ? order.tableNo == null
+                  ? "Dine-In"
+                  : `Table No: ${order.tableNo}`
                 : "Takeaway"}
             </p>
           </div>

--- a/imports/ui/pages/receipt/Receipt.tsx
+++ b/imports/ui/pages/receipt/Receipt.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useTracker, useSubscribe } from "meteor/react-meteor-data";
 import { useNavigate, useLocation } from "react-router";
 import { OrdersCollection } from "/imports/api/orders/OrdersCollection";
-import { TablesCollection } from "/imports/api/tables/TablesCollection";
 
 export const ReceiptPage = () => {
   const navigate = useNavigate(); // For navigating between PaymentModal and Receipt
@@ -12,23 +11,9 @@ export const ReceiptPage = () => {
   const orderNumber = searchParams.get("orderNo"); // Get order number based on URL
 
   useSubscribe("orders");
-  useSubscribe("tables");
-
-  // Find the lowest table number which is occupied
-  const lowestOccupiedTableNo = useTracker(() => {
-    const occupiedTables = TablesCollection.find(
-      { isOccupied: true },
-      { sort: { tableNo: 1 } },
-    ).fetch();
-    return occupiedTables.length > 0 ? occupiedTables[0].tableNo : null;
-  }, []);
 
   const handleGoBack = () => {
-    if (lowestOccupiedTableNo !== null) {
-      navigate(`/pos/orders?tableNo=${lowestOccupiedTableNo}`);
-    } else {
-      navigate("/pos/orders");
-    }
+    navigate("/pos/orders");
   };
 
   // Retrieve order based on order number in URL from PaymentModal

--- a/imports/ui/pages/receipt/Receipt.tsx
+++ b/imports/ui/pages/receipt/Receipt.tsx
@@ -1,26 +1,38 @@
 import React from "react";
 import { useTracker, useSubscribe } from "meteor/react-meteor-data";
-import { useNavigate, useLocation } from "react-router";
+import { useNavigate } from "react-router";
 import { OrdersCollection } from "/imports/api/orders/OrdersCollection";
 
 export const ReceiptPage = () => {
-  const navigate = useNavigate(); // For navigating between PaymentModal and Receipt
-
-  const location = useLocation(); // Get URL details
-  const searchParams = new URLSearchParams(location.search); // Get URL search parameters
-  const orderNumber = searchParams.get("orderNo"); // Get order number based on URL
-
+  const navigate = useNavigate();
   useSubscribe("orders");
 
+  // Get orderId from sessionStorage
+  const orderId = sessionStorage.getItem("activeOrderId");
+
+  // Find lowest unpaid dine-in order
+  const lowestDineInOrderId = useTracker(() => {
+    const orders = OrdersCollection.find(
+      { orderType: "dine-in", paid: false },
+      { sort: { orderNo: 1 } }
+    ).fetch();
+    return orders.length > 0 ? orders[0]._id : null;
+  }, []);
+
   const handleGoBack = () => {
+    if (lowestDineInOrderId) {
+      sessionStorage.setItem("activeOrderId", lowestDineInOrderId);
+    } else {
+      sessionStorage.removeItem("activeOrderId");
+    }
     navigate("/pos/orders");
   };
 
-  // Retrieve order based on order number in URL from PaymentModal
-  const parsedOrderNumber = Number(orderNumber);
+  // Retrieve order by _id
   const order = useTracker(() => {
-    return OrdersCollection.find({ orderNo: parsedOrderNumber }).fetch()[0];
-  }, [orderNumber]);
+    if (!orderId) return null;
+    return OrdersCollection.findOne(orderId) ?? null;
+  }, [orderId]);
 
   if (!order) {
     return (


### PR DESCRIPTION
Features:
- A user can now create a new Order without being associated with a Table
- POS Side Menu's dine-in dropdown displays a list of order IDs rather than table numbers
- A user can add an Order to a Table from the Tables page
- OrderCard and Receipt display "Dine In
- Updated to using session storage for reloading data across pages (rather than using URL parameters)
- Refactored OrderType to be an Enum

- Added a "Go To Order" button for Tables which have an active order which takes user to the order in POS page

Screenshots:
New dropdown list for dine-in
<img width="314" height="644" alt="image" src="https://github.com/user-attachments/assets/9d751883-3549-46c0-b838-bc949fcd4b9d" />

Only unassigned dine-in orders are available to add to a Table
<img width="667" height="560" alt="image" src="https://github.com/user-attachments/assets/dd221204-7eda-4702-add8-78928b62b668" />

OrderCard updated to display Dine-In for unassigned dine in orders.
<img width="318" height="194" alt="image" src="https://github.com/user-attachments/assets/5ae94244-a43a-49d3-8e06-d5d51d714a03" />

Go To Order button displayed for Table with active order.
<img width="346" height="429" alt="image" src="https://github.com/user-attachments/assets/379d24cd-f386-4f1f-828b-5cb6bd24fda7" />

Go To Order button not displayed for Table without active order (despite being occupied).
<img width="337" height="423" alt="image" src="https://github.com/user-attachments/assets/6db6ef42-c6d6-46fe-8a1a-fe3964a97aab" />
