### PR TITLE
Refactor/enhancement team 1

### DIFF
--- a/imports/api/orders/OrdersCollection.ts
+++ b/imports/api/orders/OrdersCollection.ts
@@ -29,6 +29,7 @@ export enum OrderStatus {
   Preparing = "preparing",
   Ready = "ready",
   Served = "served",
+  Paid = "paid",
 }
 
 export enum OrderType {

--- a/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
+++ b/imports/ui/components/KitchenMgmtComponents/KitchenMgmtTypes.tsx
@@ -1,7 +1,5 @@
 import { IdType } from "/imports/api/database";
-import { OrderType } from "/imports/api/orders/OrdersCollection";
-
-export type OrderStatus = "pending" | "preparing" | "ready" | "served";
+import { OrderType, OrderStatus } from "/imports/api/orders/OrdersCollection";
 
 export type UiOrder = {
   _id: IdType;

--- a/imports/ui/components/PaymentModal.tsx
+++ b/imports/ui/components/PaymentModal.tsx
@@ -29,7 +29,10 @@ export const PaymentModal = ({ order }: PaymentModalProps) => {
   const finalizePayment = () => {
     if (!order || !order._id) return;
 
-    Meteor.call("orders.updateOrder", order._id, { paid: true });
+    Meteor.call("orders.updateOrder", order._id, {
+      paid: true,
+      orderStatus: OrderStatus.Paid,
+    });
 
     // Clear the table if dine-in
     if (order.tableNo !== null && order.tableNo !== undefined) {

--- a/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
+++ b/imports/ui/pages/kitchenManagement/KitchenManagement.tsx
@@ -10,13 +10,14 @@ import { useTracker } from "meteor/react-meteor-data";
 import {
   OrdersCollection,
   Order as DBOrder,
+  OrderStatus
 } from "../../../api/orders/OrdersCollection";
 import { DndContext, DragEndEvent } from "@dnd-kit/core";
 
 const COLUMNS: ColumnType[] = [
-  { id: "pending", title: "Pending" },
-  { id: "preparing", title: "Preparing" },
-  { id: "ready", title: "Ready" },
+  { id: OrderStatus.Pending,   title: "Pending" },
+  { id: OrderStatus.Preparing, title: "Preparing" },
+  { id: OrderStatus.Ready,     title: "Ready" },
 ];
 
 export const KitchenManagement = () => {
@@ -59,12 +60,12 @@ export const KitchenManagement = () => {
     if (!over) return;
 
     const orderId = String(active.id);
-    const newStatus = over.id;
+    const next = String(over.id) as OrderStatus;
 
     Meteor.call(
       "orders.updateOrder",
       orderId,
-      { orderStatus: newStatus },
+      { orderStatus: next },
       (err: Meteor.Error | undefined) => {
         if (err) {
           console.error(err);

--- a/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
+++ b/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
@@ -1,5 +1,3 @@
-// imports/ui/pages/kitchen/OrderHistoryPage.tsx
-
 import { useEffect, useMemo, useState } from "react";
 import { useTracker } from "meteor/react-meteor-data";
 import { Meteor } from "meteor/meteor";
@@ -9,7 +7,6 @@ import {
   Order as DBOrder,
 } from "../../../api/orders/OrdersCollection";
 
-// Use shared UI components (Roster style)
 import { Button } from "../../components/interaction/Button";
 import { Select } from "../../components/interaction/Select";
 import { Input } from "../../components/interaction/Input";
@@ -19,19 +16,17 @@ type RowOrder = {
   orderNo: number;
   tableNo: number | null;
   createdAt: string;
-  status: "pending" | "preparing" | "ready" | "served";
+  status: "pending" | "preparing" | "ready" | "served" | "paid";
   items: string;
   paid: boolean;
 };
 
 export const OrderHistoryPage = () => {
-  // Page title (same pattern as RosterPage)
   const [_, setPageTitle] = usePageTitle();
   useEffect(() => {
     setPageTitle("Kitchen Management - Order History");
   }, [setPageTitle]);
 
-  // Subscribe + map DB docs to flat rows for display
   const orders: RowOrder[] = useTracker(() => {
     const sub = Meteor.subscribe("orders");
     if (!sub.ready()) return [];
@@ -41,7 +36,7 @@ export const OrderHistoryPage = () => {
       orderNo: doc.orderNo,
       tableNo: doc.tableNo ?? null,
       createdAt: new Date(doc.createdAt).toLocaleString(),
-      status: doc.orderStatus,
+      status: doc.orderStatus as RowOrder["status"],
       items: (doc.menuItems ?? [])
         .map((mi) => `${mi.name} x${mi.quantity ?? 1}`)
         .join(", "),
@@ -49,22 +44,22 @@ export const OrderHistoryPage = () => {
     }));
   }, []);
 
-  // ---- Controls state ----
-  const [statusFilter, setStatusFilter] = useState<"served" | "all">("served");
+  const [statusFilter, setStatusFilter] =
+    useState<"served" | "paid" | "all">("served");
   const [q, setQ] = useState("");
 
-  // ---- Filtering ----
   const filtered = useMemo(() => {
-    const base =
+    let base =
       statusFilter === "served"
         ? orders.filter((o) => o.status === "served")
-        : orders;
+        : statusFilter === "paid"
+          ? orders.filter((o) => o.status === "paid")
+          : orders;
 
     if (!q.trim()) return base;
 
     const key = q.toLowerCase();
     return base.filter((o) => {
-      // EN: If no table number, treat it as "takeaway" for searching
       const tableText = o.tableNo != null ? String(o.tableNo) : "takeaway";
       return (
         String(o.orderNo).includes(key) ||
@@ -74,7 +69,6 @@ export const OrderHistoryPage = () => {
     });
   }, [orders, statusFilter, q]);
 
-  // ---- Actions ----
   const reopen = (id: string, to: RowOrder["status"]) => {
     Meteor.call(
       "orders.updateOrder",
@@ -89,33 +83,25 @@ export const OrderHistoryPage = () => {
     );
   };
 
-  // ---- Render ----
   return (
     <div className="flex flex-1 flex-col p-6 gap-4 overflow-hidden">
-      {/* Page heading (Roster style) */}
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-press-up-purple">
-          Order History
-        </h1>
+        <h1 className="text-2xl font-bold text-press-up-purple">Order History</h1>
       </div>
 
-      {/* Controls bar */}
+      {/* Controls */}
       <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-end">
-        {/* Filter dropdown (shared Select) */}
         <div className="w-full sm:w-60">
-          {/* EN: Controlled Select, integrates with statusFilter */}
           <Select
             value={statusFilter}
-            onChange={(e) =>
-              setStatusFilter(e.target.value as "served" | "all")
-            }
+            onChange={(e) => setStatusFilter(e.target.value as "served" | "paid" | "all")}
           >
             <option value="served">Served only</option>
+            <option value="paid">Paid only</option>
             <option value="all">All statuses</option>
           </Select>
         </div>
 
-        {/* Search input (shared Input) */}
         <div className="w-full sm:flex-1">
           <Input
             placeholder="Search (order/table/item)"
@@ -125,7 +111,7 @@ export const OrderHistoryPage = () => {
         </div>
       </div>
 
-      {/* Table container */}
+      {/* Table */}
       <div className="overflow-auto flex-1 rounded-lg border border-gray-200 bg-white">
         <table className="min-w-full text-left">
           <thead className="sticky top-0 z-10">
@@ -141,12 +127,15 @@ export const OrderHistoryPage = () => {
 
           <tbody className="divide-y divide-gray-100">
             {filtered.map((row) => {
-              const isPaid =
-                orders.find((o) => o._id === row._id)?.paid === true;
+              const isPaid = orders.find((o) => o._id === row._id)?.paid === true;
 
-              // EN: Simple badge for status
+              // ✅ Status badge: PAID 추가
               const statusBadge =
-                row.status === "served" ? (
+                row.status === "paid" ? (
+                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-purple-700 text-white">
+                    PAID
+                  </span>
+                ) : row.status === "served" ? (
                   <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-green-600 text-white">
                     {row.status.toUpperCase()}
                   </span>
@@ -180,7 +169,6 @@ export const OrderHistoryPage = () => {
                   </td>
                   <td className="py-2 px-3">
                     <div className="flex justify-end gap-2">
-                      {/* EN: Reopen to Ready */}
                       <Button
                         disabled={isPaid}
                         onClick={() => reopen(row._id, "ready")}
@@ -189,7 +177,6 @@ export const OrderHistoryPage = () => {
                         Reopen: Ready
                       </Button>
 
-                      {/* EN: Reopen to Preparing */}
                       <Button
                         disabled={isPaid}
                         onClick={() => reopen(row._id, "preparing")}
@@ -205,9 +192,7 @@ export const OrderHistoryPage = () => {
 
             {filtered.length === 0 && (
               <tr className="grid grid-cols-1">
-                <td className="py-8 text-center text-gray-500">
-                  No orders found.
-                </td>
+                <td className="py-8 text-center text-gray-500">No orders found.</td>
               </tr>
             )}
           </tbody>

--- a/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
+++ b/imports/ui/pages/kitchenManagement/OrderHistoryPage.tsx
@@ -45,7 +45,7 @@ export const OrderHistoryPage = () => {
   }, []);
 
   const [statusFilter, setStatusFilter] =
-    useState<"served" | "paid" | "all">("served");
+    useState<"served" | "paid" | "all">("all");
   const [q, setQ] = useState("");
 
   const filtered = useMemo(() => {
@@ -53,8 +53,8 @@ export const OrderHistoryPage = () => {
       statusFilter === "served"
         ? orders.filter((o) => o.status === "served")
         : statusFilter === "paid"
-          ? orders.filter((o) => o.status === "paid")
-          : orders;
+        ? orders.filter((o) => o.status === "paid")
+        : orders;
 
     if (!q.trim()) return base;
 
@@ -129,29 +129,25 @@ export const OrderHistoryPage = () => {
             {filtered.map((row) => {
               const isPaid = orders.find((o) => o._id === row._id)?.paid === true;
 
-              // ✅ Status badge: PAID 추가
-              const statusBadge =
-                row.status === "paid" ? (
-                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-purple-700 text-white">
-                    PAID
-                  </span>
-                ) : row.status === "served" ? (
-                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-green-600 text-white">
-                    {row.status.toUpperCase()}
-                  </span>
-                ) : row.status === "ready" ? (
-                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-yellow-600 text-white">
-                    {row.status.toUpperCase()}
-                  </span>
-                ) : row.status === "preparing" ? (
-                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-blue-600 text-white">
-                    {row.status.toUpperCase()}
-                  </span>
-                ) : (
-                  <span className="inline-block px-2 py-0.5 rounded-md text-xs font-bold bg-gray-600 text-white">
-                    {row.status.toUpperCase()}
-                  </span>
-                );
+              // Unified badge for all statuses
+              const statusBadge = (() => {
+                const base =
+                  "inline-block px-2 py-0.5 rounded-md text-xs font-bold text-white";
+                switch (row.status) {
+                  case "pending":
+                    return <span className={`${base} bg-gray-500`}>PENDING</span>;
+                  case "preparing":
+                    return <span className={`${base} bg-blue-600`}>PREPARING</span>;
+                  case "ready":
+                    return <span className={`${base} bg-yellow-600`}>READY</span>;
+                  case "served":
+                    return <span className={`${base} bg-green-600`}>SERVED</span>;
+                  case "paid":
+                    return <span className={`${base} bg-purple-700`}>PAID</span>;
+                  default:
+                    return <span className={`${base} bg-gray-600`}>{(row.status as string).toUpperCase()}</span>;
+                }
+              })();
 
               return (
                 <tr
@@ -167,24 +163,26 @@ export const OrderHistoryPage = () => {
                   <td className="py-2 px-3 truncate" title={row.items}>
                     {row.items || <em className="text-gray-500">No items</em>}
                   </td>
-                  <td className="py-2 px-3">
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        disabled={isPaid}
-                        onClick={() => reopen(row._id, "ready")}
-                        className="!bg-transparent !text-press-up-purple !border !border-press-up-purple hover:!bg-press-up-purple/10 disabled:opacity-50"
-                      >
-                        Reopen: Ready
-                      </Button>
 
-                      <Button
-                        disabled={isPaid}
-                        onClick={() => reopen(row._id, "preparing")}
-                        className="!bg-transparent !text-press-up-purple !border !border-press-up-purple hover:!bg-press-up-purple/10 disabled:opacity-50"
-                      >
-                        Reopen: Preparing
-                      </Button>
-                    </div>
+                  {/* Only show actions for SERVED & not paid */}
+                  <td className="py-2 px-3">
+                    {row.status === "served" && !isPaid && (
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          onClick={() => reopen(row._id, "ready")}
+                          className="!bg-transparent !text-press-up-purple !border !border-press-up-purple hover:!bg-press-up-purple/10"
+                        >
+                          Reopen: Ready
+                        </Button>
+
+                        <Button
+                          onClick={() => reopen(row._id, "preparing")}
+                          className="!bg-transparent !text-press-up-purple !border !border-press-up-purple hover:!bg-press-up-purple/10"
+                        >
+                          Reopen: Preparing
+                        </Button>
+                      </div>
+                    )}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
Fix order status based on Team 2’s suggestion
What changed

1. Added a new status, “paid,” which comes after “served” and is set when the customer pays for the order.

2. Reopen actions are now hidden for all statuses except “served.”

<img width="819" height="1101" alt="image" src="https://github.com/user-attachments/assets/abe67f76-04c1-4a70-9092-be31e101e3f3" />
<img width="505" height="53" alt="image" src="https://github.com/user-attachments/assets/065bcce0-ac32-4296-99be-947f0c23c819" />
